### PR TITLE
feat(tui-big-text)!: make `BigText` builder infallible

### DIFF
--- a/tui-big-text/README.md
+++ b/tui-big-text/README.md
@@ -35,7 +35,7 @@ use anyhow::Result;
 use ratatui::prelude::*;
 use tui_big_text::{BigText, PixelSize};
 
-fn render(frame: &mut Frame) -> Result<()> {
+fn render(frame: &mut Frame) {
     let big_text = BigText::builder()
         .pixel_size(PixelSize::Full)
         .style(Style::new().blue())
@@ -44,9 +44,8 @@ fn render(frame: &mut Frame) -> Result<()> {
             "World".white().into(),
             "~~~~~".into(),
         ])
-        .build()?;
+        .build();
     frame.render_widget(big_text, frame.size());
-    Ok(())
 }
 ```
 

--- a/tui-big-text/examples/alignment.rs
+++ b/tui-big-text/examples/alignment.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn render(frame: &mut Frame) -> Result<()> {
+fn render(frame: &mut Frame) {
     let title = Line::from("tui-big-text alignment demo. Press 'q' to quit")
         .cyan()
         .centered();
@@ -23,19 +23,19 @@ fn render(frame: &mut Frame) -> Result<()> {
         .pixel_size(PixelSize::Quadrant)
         .left_aligned()
         .lines(vec!["Left".white().into()])
-        .build()?;
+        .build();
 
     let right = BigText::builder()
         .pixel_size(PixelSize::Quadrant)
         .right_aligned()
         .lines(vec!["Right".green().into()])
-        .build()?;
+        .build();
 
     let centered = BigText::builder()
         .pixel_size(PixelSize::Quadrant)
         .centered()
         .lines(vec!["Centered".red().into()])
-        .build()?;
+        .build();
 
     let area = frame.size();
     frame.render_widget(title, area);
@@ -44,6 +44,4 @@ fn render(frame: &mut Frame) -> Result<()> {
     frame.render_widget(left, area);
     frame.render_widget(right, area);
     frame.render_widget(centered, area);
-
-    Ok(())
 }

--- a/tui-big-text/examples/big_text.rs
+++ b/tui-big-text/examples/big_text.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn render(frame: &mut Frame) -> Result<()> {
+fn render(frame: &mut Frame) {
     let title = Line::from("tui-big-text Demo. Press 'q' to quit").cyan();
 
     let big_text = BigText::builder()
@@ -24,12 +24,11 @@ fn render(frame: &mut Frame) -> Result<()> {
             "big-".white().into(),
             "text".into(),
         ])
-        .build()?;
+        .build();
 
     let area = frame.size();
     frame.render_widget(title, area);
 
     let area = area.offset(Offset { x: 0, y: 2 }).intersection(area);
     frame.render_widget(big_text, area);
-    Ok(())
 }

--- a/tui-big-text/examples/common/mod.rs
+++ b/tui-big-text/examples/common/mod.rs
@@ -16,12 +16,12 @@ type Terminal = ratatui::Terminal<CrosstermBackend<io::Stdout>>;
 /// user presses 'q' or 'Esc'
 pub fn run<F>(render: F) -> Result<()>
 where
-    F: Fn(&mut ratatui::Frame) -> Result<()>,
+    F: Fn(&mut ratatui::Frame),
 {
     install_panic_handler();
 
     with_terminal(|mut terminal| loop {
-        terminal.draw(|frame| render(frame).expect("failed to render"))?;
+        terminal.draw(|frame| render(frame))?;
         if let crossterm::event::Event::Key(event) = crossterm::event::read()? {
             if matches!(
                 event.code,

--- a/tui-big-text/examples/pixel_size.rs
+++ b/tui-big-text/examples/pixel_size.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn render(frame: &mut Frame) -> Result<()> {
+fn render(frame: &mut Frame) {
     let title = Line::from("tui-big-text pixel size demo. Press 'q' to quit")
         .centered()
         .cyan();
@@ -18,32 +18,32 @@ fn render(frame: &mut Frame) -> Result<()> {
     let full_size_text = BigText::builder()
         .pixel_size(PixelSize::Full)
         .lines(vec!["FullSize".white().into()])
-        .build()?;
+        .build();
 
     let half_height_text = BigText::builder()
         .pixel_size(PixelSize::HalfHeight)
         .lines(vec!["1/2 high".green().into()])
-        .build()?;
+        .build();
 
     let half_wide_text = BigText::builder()
         .pixel_size(PixelSize::HalfWidth)
         .lines(vec!["1/2 wide".red().into()])
-        .build()?;
+        .build();
 
     let quadrant_text = BigText::builder()
         .pixel_size(PixelSize::Quadrant)
         .lines(vec!["Quadrant".blue().into(), " 1/2*1/2".blue().into()])
-        .build()?;
+        .build();
 
     let third_text = BigText::builder()
         .pixel_size(PixelSize::ThirdHeight)
         .lines(vec!["1/3".yellow().into(), "high".yellow().into()])
-        .build()?;
+        .build();
 
     let sextant_text = BigText::builder()
         .pixel_size(PixelSize::Sextant)
         .lines(vec!["Sextant".cyan().into(), " 1/2*1/3".cyan().into()])
-        .build()?;
+        .build();
 
     // Setup layout for the title and 6 blocks
     use Constraint::*;
@@ -60,6 +60,4 @@ fn render(frame: &mut Frame) -> Result<()> {
     frame.render_widget(quadrant_text, quadrant);
     frame.render_widget(third_text, third_height);
     frame.render_widget(sextant_text, sextant);
-
-    Ok(())
 }

--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -142,11 +142,7 @@ impl StopwatchApp {
         };
         let duration = format_duration(self.elapsed());
         let lines = vec![duration.into()];
-        BigText::builder()
-            .lines(lines)
-            .style(style)
-            .build()
-            .unwrap()
+        BigText::builder().lines(lines).style(style).build()
     }
 
     /// Renders the splits as a list of lines.

--- a/tui-big-text/src/lib.rs
+++ b/tui-big-text/src/lib.rs
@@ -31,7 +31,7 @@
 //! use ratatui::prelude::*;
 //! use tui_big_text::{BigText, PixelSize};
 //!
-//! fn render(frame: &mut Frame) -> Result<()> {
+//! fn render(frame: &mut Frame) {
 //!     let big_text = BigText::builder()
 //!         .pixel_size(PixelSize::Full)
 //!         .style(Style::new().blue())
@@ -40,9 +40,8 @@
 //!             "World".white().into(),
 //!             "~~~~~".into(),
 //!         ])
-//!         .build()?;
+//!         .build();
 //!     frame.render_widget(big_text, frame.size());
-//!     Ok(())
 //! }
 //! ```
 //!


### PR DESCRIPTION
BigTextBuilder.build() no longer returns a Result. Instead it returns
the BigText widget directly. This change is made to simplify rendering
code which often otherwise doesn't have any error conditions.

This also makes the fields on BigText public (marked as non-exhaustive)

BREAKING CHANGE: BigTextBuilder.build() no longer returns a Result.

Remove the `?` / `expect` / `unwrap` calls code which calls the build
method.

```diff
 let big_text = BigText::builder()
     .lines(vec![Line::from("SingleLine")])
-    .build()?;
+    .build();
```
