### PR TITLE
fix: make all tests and crates compileable with ratatui 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.21"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
-ratatui = { version = "0.27.0", default-features = false }
+ratatui = { version = "0.28" }
 ratatui-macros = "0.4.2"
 rstest = "0.22.0"
 strum = { version = "0.26.1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.21"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
-ratatui = { version = "0.28" }
+ratatui = { version = "0.28", default-features = false }
 ratatui-macros = "0.4.2"
 rstest = "0.22.0"
 strum = { version = "0.26.1", features = ["derive"] }

--- a/tui-big-text/examples/alignment.rs
+++ b/tui-big-text/examples/alignment.rs
@@ -37,7 +37,7 @@ fn render(frame: &mut Frame) {
         .lines(vec!["Centered".red().into()])
         .build();
 
-    let area = frame.size();
+    let area = frame.area();
     frame.render_widget(title, area);
 
     let area = area.offset(Offset { x: 0, y: 2 }).intersection(area);

--- a/tui-big-text/examples/big_text.rs
+++ b/tui-big-text/examples/big_text.rs
@@ -26,7 +26,7 @@ fn render(frame: &mut Frame) {
         ])
         .build();
 
-    let area = frame.size();
+    let area = frame.area();
     frame.render_widget(title, area);
 
     let area = area.offset(Offset { x: 0, y: 2 }).intersection(area);

--- a/tui-big-text/examples/pixel_size.rs
+++ b/tui-big-text/examples/pixel_size.rs
@@ -49,7 +49,7 @@ fn render(frame: &mut Frame) {
     use Constraint::*;
     let [top, full, half_height, middle, bottom] =
         Layout::vertical([Length(2), Length(8), Length(4), Length(8), Length(6)])
-            .areas(frame.size());
+            .areas(frame.area());
     let [half_wide, quadrant] = Layout::horizontal([Length(32), Length(32)]).areas(middle);
     let [third_height, sextant] = Layout::horizontal([Length(32), Length(32)]).areas(bottom);
 

--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -119,7 +119,7 @@ impl StopwatchApp {
 
     fn draw(&mut self, tui: &mut Tui) -> Result<()> {
         tui.draw(|frame| {
-            let layout = layout(frame.size());
+            let layout = layout(frame.area());
             frame.render_widget(Paragraph::new("Stopwatch Example"), layout[0]);
             frame.render_widget(self.fps_paragraph(), layout[1]);
             frame.render_widget(self.timer_paragraph(), layout[2]);

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -196,7 +196,7 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: &Pixel
             .clone()
             .zip(area.left()..area.right())
         {
-            let cell = buf.get_mut(x, y);
+            let cell = &mut buf[Position { x, y }];
             let symbol_character = pixel_size.symbol_for_position(&glyph, row, col);
             cell.set_char(symbol_character);
         }

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -191,14 +191,9 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: &Pixel
     let glyph_vertical_index = (0..glyph.len()).step_by(step_y as usize);
     let glyph_horizontal_bit_selector = (0..8).step_by(step_x as usize);
 
-    for (row, y) in glyph_vertical_index.zip(area.top()..area.bottom()) {
-        for (col, x) in glyph_horizontal_bit_selector
-            .clone()
-            .zip(area.left()..area.right())
-        {
-            let cell = &mut buf[Position { x, y }];
-            let symbol_character = pixel_size.symbol_for_position(&glyph, row, col);
-            cell.set_char(symbol_character);
+    for (y, row) in glyph_vertical_index.zip(area.rows()) {
+        for (x, col) in glyph_horizontal_bit_selector.clone().zip(row.columns()) {
+            buf[col].set_char(pixel_size.symbol_for_position(&glyph, y, x));
         }
     }
 }

--- a/tui-popup/examples/paragraph.rs
+++ b/tui-popup/examples/paragraph.rs
@@ -29,7 +29,7 @@ struct App {
 
 impl App {
     fn render(&self, frame: &mut Frame) {
-        let area = frame.size();
+        let area = frame.area();
         let background = background(area);
 
         let paragraph = paragraph(self.scroll);

--- a/tui-popup/examples/popup.rs
+++ b/tui-popup/examples/popup.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
 }
 
 fn render(frame: &mut Frame) {
-    let area = frame.size();
+    let area = frame.area();
     let background = background(area);
     let popup = Popup::new("Press any key to exit")
         .title("tui-popup demo")

--- a/tui-popup/examples/state.rs
+++ b/tui-popup/examples/state.rs
@@ -29,7 +29,7 @@ struct App {
 impl App {
     fn render(&mut self, frame: &mut Frame) {
         let [background_area, status_area] =
-            Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.size());
+            Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
 
         let background = Self::background(background_area);
         frame.render_widget(background, background_area);

--- a/tui-prompts/Cargo.toml
+++ b/tui-prompts/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 
 [dependencies]
 itertools.workspace = true
-ratatui.workspace = true
+ratatui = { workspace = true, features = ["crossterm"] }
 ratatui-macros.workspace = true
 rstest.workspace = true
 

--- a/tui-prompts/examples/multi_line.rs
+++ b/tui-prompts/examples/multi_line.rs
@@ -71,7 +71,7 @@ impl<'a> App<'a> {
     }
 
     fn draw_ui(&mut self, frame: &mut Frame) {
-        let (text_area, debug_area) = self.split_layout(frame.size());
+        let (text_area, debug_area) = self.split_layout(frame.area());
         self.draw_text_prompt(frame, text_area);
         self.draw_debug(frame, debug_area);
     }
@@ -79,6 +79,7 @@ impl<'a> App<'a> {
     /// split the frame into 2 areas:
     /// - prompt area
     /// - debug area
+    ///
     /// The debug area is only visible if the `debug` flag is set.
     fn split_layout(&self, area: Rect) -> (Rect, Rect) {
         if self.debug {

--- a/tui-prompts/examples/text.rs
+++ b/tui-prompts/examples/text.rs
@@ -74,7 +74,7 @@ impl<'a> App<'a> {
 
     fn draw_ui(&mut self, frame: &mut Frame) {
         let (username_area, password_area, invisible_area, value_area, debug_area) =
-            self.split_layout(frame.size());
+            self.split_layout(frame.area());
         self.draw_text_prompt(frame, username_area);
         self.draw_password_prompt(frame, password_area);
         self.draw_invisible_prompt(frame, invisible_area);
@@ -88,6 +88,7 @@ impl<'a> App<'a> {
     /// - invisible prompt
     /// - state value
     /// - debug area
+    ///
     /// The debug area is only visible if the `debug` flag is set.
     fn split_layout(&self, area: Rect) -> (Rect, Rect, Rect, Rect, Rect) {
         let (prompt_area, debug_area) = if self.debug {

--- a/tui-prompts/src/text_prompt.rs
+++ b/tui-prompts/src/text_prompt.rs
@@ -367,9 +367,12 @@ mod tests {
         let prompt = TextPrompt::from("prompt");
         let mut state = TextState::new().with_value("hello");
         // The cursor is not changed when the prompt is not focused.
-        let _ = terminal.draw(|frame| prompt.draw(frame, frame.size(), &mut state))?;
+        let _ = terminal.draw(|frame| prompt.draw(frame, frame.area(), &mut state))?;
         assert_eq!(state.cursor(), (11, 0));
-        assert_eq!(terminal.backend_mut().get_cursor().unwrap(), (0, 0));
+        assert_eq!(
+            terminal.backend_mut().get_cursor_position().unwrap(),
+            Position::ORIGIN
+        );
         Ok(())
     }
 
@@ -379,9 +382,12 @@ mod tests {
         let mut state = TextState::new().with_value("hello");
         // The cursor is changed when the prompt is focused.
         state.focus();
-        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.size(), &mut state))?;
+        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.area(), &mut state))?;
         assert_eq!(state.cursor(), (11, 0));
-        assert_eq!(terminal.backend_mut().get_cursor().unwrap(), (11, 0));
+        assert_eq!(
+            terminal.backend_mut().get_cursor_position().unwrap(),
+            Position::new(11, 0)
+        );
         Ok(())
     }
 
@@ -408,9 +414,9 @@ mod tests {
         // The cursor is changed when the prompt is focused and the position is changed.
         state.focus();
         *state.position_mut() = position;
-        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.size(), &mut state))?;
+        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.area(), &mut state))?;
         assert_eq!(state.cursor(), expected_cursor);
-        assert_eq!(terminal.get_cursor()?, expected_cursor);
+        assert_eq!(terminal.get_cursor_position()?, expected_cursor.into());
 
         Ok(())
     }
@@ -442,9 +448,9 @@ mod tests {
         // The cursor is changed when the prompt is focused and the position is changed.
         state.focus();
         *state.position_mut() = position;
-        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.size(), &mut state))?;
+        let _ = terminal.draw(|frame| prompt.clone().draw(frame, frame.area(), &mut state))?;
         assert_eq!(state.cursor(), expected_cursor);
-        assert_eq!(terminal.get_cursor()?, expected_cursor);
+        assert_eq!(terminal.get_cursor_position()?, expected_cursor.into());
 
         Ok(())
     }

--- a/tui-prompts/src/text_prompt.rs
+++ b/tui-prompts/src/text_prompt.rs
@@ -75,7 +75,7 @@ impl Prompt for TextPrompt<'_> {
     fn draw(self, frame: &mut Frame, area: Rect, state: &mut Self::State) {
         frame.render_stateful_widget(self, area, state);
         if state.is_focused() {
-            frame.set_cursor(state.cursor().0, state.cursor().1);
+            frame.set_cursor_position(state.cursor());
         }
     }
 }

--- a/tui-scrollview/examples/scrollview.rs
+++ b/tui-scrollview/examples/scrollview.rs
@@ -62,7 +62,7 @@ impl App {
     }
 
     fn draw(&mut self, terminal: &mut Terminal<impl Backend>) -> io::Result<()> {
-        terminal.draw(|frame| frame.render_widget(self, frame.size()))?;
+        terminal.draw(|frame| frame.render_widget(self, frame.area()))?;
         Ok(())
     }
 

--- a/tui-scrollview/examples/tabs.rs
+++ b/tui-scrollview/examples/tabs.rs
@@ -134,7 +134,7 @@ impl App {
     }
 
     fn draw(&mut self, tui: &mut Tui) -> io::Result<()> {
-        tui.draw(|frame| frame.render_widget(self, frame.size()))?;
+        tui.draw(|frame| frame.render_widget(self, frame.area()))?;
         Ok(())
     }
 

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -195,14 +195,7 @@ impl ScrollView {
         // TODO: there's probably a more efficient way to do this
         for (src_row, dst_row) in visible_area.rows().zip(area.rows()) {
             for (src_col, dst_col) in src_row.columns().zip(dst_row.columns()) {
-                buf[Position {
-                    x: dst_col.x,
-                    y: dst_col.y,
-                }] = self.buf[Position {
-                    x: src_col.x,
-                    y: src_col.y,
-                }]
-                .clone();
+                buf[dst_col] = self.buf[src_col].clone();
             }
         }
     }

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -195,7 +195,14 @@ impl ScrollView {
         // TODO: there's probably a more efficient way to do this
         for (src_row, dst_row) in visible_area.rows().zip(area.rows()) {
             for (src_col, dst_col) in src_row.columns().zip(dst_row.columns()) {
-                *buf.get_mut(dst_col.x, dst_col.y) = self.buf.get(src_col.x, src_col.y).clone();
+                buf[Position {
+                    x: dst_col.x,
+                    y: dst_col.y,
+                }] = self.buf[Position {
+                    x: src_col.x,
+                    y: src_col.y,
+                }]
+                .clone();
             }
         }
     }


### PR DESCRIPTION
Working on one of my projects, I found out, I was not able to build with ratatui 0.28 and any version of tui-big-text.
With this pull request, I want to mak the crates from this repository compilable with ratatui 0.28.

With these two changes, I am able to build my project against ratatui 0.28 and tui-big-text from this branch. And all tests and crates from this repository can be built and run again.

After this branch is merged, all components need new versions, I think.