### PR TITLE
[fix]: Misconfiguration in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,3 @@ tui-popup = { version = "0.5.0", path = "tui-popup", optional = true }
 tui-prompts = { version = "0.4.0", path = "tui-prompts", optional = true }
 tui-scrollview = { version = "0.4.0", path = "tui-scrollview", optional = true }
 
-[patch.crates-io]
-ratatui = { path = "../ratatui" }


### PR DESCRIPTION
Those two lines were added (mistakenly I suppose) in [`a35d3b46f17ec53a6f2a3c39ff5a75155adc1e95`](https://github.com/joshka/tui-widgets/commit/a35d3b46f17ec53a6f2a3c39ff5a75155adc1e95#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R78)  and are since making all the tests fail, as well as **preventing the library from compiling out of the box from the github repo.**

![image](https://github.com/user-attachments/assets/15d7565a-7c2d-4cbf-bce2-bf461c56aa57)
![image](https://github.com/user-attachments/assets/3755fe5b-e25d-4c5a-80ca-8673f0b2f8c9)
