### PR TITLE
chore: make compilable with ratatui 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3.21"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
-ratatui = { version = "0.28.1", default-features = false }
+ratatui = { version = ">=0.28", default-features = false }  # Currently compatible with 0.28 and 0.29
 ratatui-macros = "0.5.0"
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["command-line-interface", "gui"]
 keywords = ["cli", "console", "ratatui", "terminal", "tui"]
 
 [workspace.dependencies]
-clap = { version = "4.5.8", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive"] }
 color-eyre = "0.6.3"
 crossterm = { version = "0.28.1" }
-derive_builder = "0.20.0"
+derive_builder = "0.20.2"
 derive-getters = "0.5.0"
 derive_setters = "0.1.6"
 document-features = "0.2.10"
-futures = "0.3.21"
+futures = "0.3.31"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
@@ -27,7 +27,7 @@ ratatui = { version = ">=0.28", default-features = false }  # Currently compatib
 ratatui-macros = "0.5.0"
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }
-tokio = { version = "1.39" }
+tokio = { version = "1.41.0" }
 
 [lints.rust]
 unused = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ futures = "0.3.31"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
-ratatui = { version = ">=0.28", default-features = false }  # Currently compatible with 0.28 and 0.29
-ratatui-macros = "0.5.0"
+ratatui = { version = "0.29.0", default-features = false }
+ratatui-macros = "0.6.0"
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.41.0" }
@@ -41,7 +41,7 @@ nursery = "warn"
 [package]
 name = "tui-widgets"
 description = "A collection of useful widgets for building terminal user interfaces using Ratatui"
-version = "0.3.1"
+version = "0.4.0"
 documentation = "https://docs.rs/tui-widgets"
 
 authors.workspace = true
@@ -70,8 +70,8 @@ cards = ["tui-cards"]
 [dependencies]
 document-features.workspace = true
 ratatui = { workspace = true }
-tui-big-text = { version = "0.6.1", path = "tui-big-text", optional = true }
-tui-cards = { version = "0.1.0", path = "tui-cards", optional = true }
-tui-popup = { version = "0.5.1", path = "tui-popup", optional = true }
-tui-prompts = { version = "0.4.1", path = "tui-prompts", optional = true }
-tui-scrollview = { version = "0.4.1", path = "tui-scrollview", optional = true }
+tui-big-text = { version = "0.7.0", path = "tui-big-text", optional = true }
+tui-cards = { version = "0.2.0", path = "tui-cards", optional = true }
+tui-popup = { version = "0.6.0", path = "tui-popup", optional = true }
+tui-prompts = { version = "0.5.0", path = "tui-prompts", optional = true }
+tui-scrollview = { version = "0.5.0", path = "tui-scrollview", optional = true }

--- a/tui-big-text/Cargo.toml
+++ b/tui-big-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-big-text"
-version = "0.6.1"
+version = "0.7.0"
 description = "A Ratatui widget for displaying big text in the terminal"
 documentation = "https://docs.rs/tui-big-text"
 

--- a/tui-box-text/Cargo.toml
+++ b/tui-box-text/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-box-text"
 description = "A Ratatui widget for displaying text using the box drawing characters"
-version = "0.1.1"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/tui-cards/Cargo.toml
+++ b/tui-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-cards"
-version = "0.1.1"
+version = "0.2.0"
 description = "A playing card widget for Ratatui"
 documentation = "https://docs.rs/tui-cards"
 

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # fn draw(frame: &mut ratatui::Frame) {
 //! let card = Card::new(Rank::Ace, Suit::Spades);
-//! frame.render_widget(&card, area);
+//! frame.render_widget(&card, frame.area());
 //! # }
 //! ```
 //!
@@ -35,7 +35,7 @@ use strum::{Display, EnumIter};
 /// use tui_cards::{Card, Rank, Suit};
 /// # fn draw(frame: &mut ratatui::Frame) {
 /// let card = Card::new(Rank::Ace, Suit::Spades);
-/// frame.render_widget(&card, area);
+/// frame.render_widget(&card, frame.area());
 /// # }
 /// ```
 #[derive(Debug, Clone, Copy)]

--- a/tui-popup/Cargo.toml
+++ b/tui-popup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-popup"
-version = "0.5.1"
+version = "0.6.0"
 description = "A simple popup for ratatui"
 documentation = "https://docs.rs/tui-popup"
 

--- a/tui-prompts/Cargo.toml
+++ b/tui-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-prompts"
-version = "0.4.1"
+version = "0.5.0"
 description = "A library for building interactive prompts for ratatui."
 
 authors.workspace = true

--- a/tui-scrollview/Cargo.toml
+++ b/tui-scrollview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-scrollview"
-version = "0.4.1"
+version = "0.5.0"
 description = "A simple scrollable view for Ratatui"
 
 authors.workspace = true


### PR DESCRIPTION
To make the crates compatible with Ratatui 0.28 and 0.29, I  changed to ">=0.28". Feel free to change this, if you don't like it.

Additionally, two example were invalid and failed when calling `cargo test --all`. I fixed those.