### PR TITLE
feat(tui-scrollview): add scrollbars visibility handling

### DIFF
--- a/tui-scrollview/src/lib.rs
+++ b/tui-scrollview/src/lib.rs
@@ -79,5 +79,5 @@
 mod scroll_view;
 mod state;
 
-pub use scroll_view::ScrollView;
+pub use scroll_view::{ScrollView, ScrollbarVisibility};
 pub use state::ScrollViewState;

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -606,7 +606,7 @@ mod tests {
     }
 
     #[rstest]
-    fn no_vertical_scrollbar(mut scroll_view: ScrollView) {
+    fn never_vertical_scrollbar(mut scroll_view: ScrollView) {
         scroll_view = scroll_view.vertical_scrollbar_visibility(ScrollbarVisibility::Never);
         let mut buf = Buffer::empty(Rect::new(0, 0, 11, 9));
         let mut state = ScrollViewState::new();
@@ -628,7 +628,7 @@ mod tests {
     }
 
     #[rstest]
-    fn no_horizontal_scrollbar(mut scroll_view: ScrollView) {
+    fn never_horizontal_scrollbar(mut scroll_view: ScrollView) {
         scroll_view = scroll_view.horizontal_scrollbar_visibility(ScrollbarVisibility::Never);
         let mut buf = Buffer::empty(Rect::new(0, 0, 9, 11));
         let mut state = ScrollViewState::new();
@@ -718,18 +718,24 @@ mod tests {
     #[rstest]
     fn does_not_render_horizontal_scrollbar(mut scroll_view: ScrollView) {
         scroll_view = scroll_view.horizontal_scrollbar_visibility(ScrollbarVisibility::Never);
-        let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
+        let mut buf = Buffer::empty(Rect::new(0, 0, 7, 6));
         let mut state = ScrollViewState::default();
         scroll_view.render(buf.area, &mut buf, &mut state);
         assert_eq!(
             buf,
             Buffer::with_lines(vec![
-                "ABCDE▲", "KLMNO█", "UVWXY█", "EFGHI█", "OPQRS║", "YZABC▼",
+                "ABCDEF▲",
+                "KLMNOP█",
+                "UVWXYZ█",
+                "EFGHIJ█",
+                "OPQRST║",
+                "YZABCD▼",
             ])
         )
     }
 
     #[rstest]
+    #[rustfmt::skip]
     fn does_not_render_both_scrollbars(mut scroll_view: ScrollView) {
         scroll_view = scroll_view.scrollbars_visibility(ScrollbarVisibility::Never);
         let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
@@ -738,7 +744,12 @@ mod tests {
         assert_eq!(
             buf,
             Buffer::with_lines(vec![
-                "ABCDEF", "KLMNOP", "UVWXYZ", "EFGHIJ", "OPQRST", "YZABCD",
+                "ABCDEF",
+                "KLMNOP",
+                "UVWXYZ",
+                "EFGHIJ",
+                "OPQRST",
+                "YZABCD",
             ])
         )
     }


### PR DESCRIPTION
Add `ScrollbarVisibility` enum with `Automatic` (default), `Always`, and `Never` variants. Also add fluent setter methods `horizontal_scrollbar_visibility()`, `vertical_scrollbar_visibility()` and `scrollbars_visibility()` to `ScrollView`.

```rust
let mut sv_no_vert = ScrollView::new(Size::new(20, 20))
    .vertical_scrollbar_visibility(ScrollbarVisibility::Never);

let mut sv_allways_bars = ScrollView::new(Size::new(50, 80))
    .scrollbars_visibility(ScrollbarVisibility::Always);
```