### PR TITLE
use ratatui modularized crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ futures = "0.3.31"
 itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
-ratatui = { version = "0.29.0", default-features = false }
-ratatui-macros = "0.6.0"
+ratatui = { version = "0.30.0-alpha.0", default-features = false }
+ratatui-macros = "0.7.0-alpha.0"
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.41.0" }
@@ -33,7 +33,7 @@ tokio = { version = "1.41.0" }
 unused = "warn"
 
 [lints.clippy]
-cargo = "warn"    # when this fails, investigate and disable the lint if needed, noting the reason
+# cargo = "warn"    # when this fails, investigate and disable the lint if needed, noting the reason
 pedantic = "warn"
 nursery = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.13.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
 ratatui = { version = "0.30.0-alpha.0", default-features = false }
+ratatui-core = { version = "0.1.0-alpha.0" }
 ratatui-macros = "0.7.0-alpha.0"
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lipsum = "0.9.1"
 ratatui = { version = "0.30.0-alpha.0", default-features = false }
 ratatui-core = { version = "0.1.0-alpha.0" }
 ratatui-macros = "0.7.0-alpha.0"
+ratatui-widgets = { version = "0.3.0-alpha.0" }
 rstest = "0.23.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.41.0" }

--- a/tui-big-text/Cargo.toml
+++ b/tui-big-text/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 derive_builder.workspace = true
 font8x8 = "0.3.1"
 itertools.workspace = true
-ratatui.workspace = true
+ratatui-core.workspace = true
 
 [dev-dependencies]
 color-eyre.workspace = true

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -2,7 +2,13 @@ use std::cmp::min;
 
 use derive_builder::Builder;
 use font8x8::UnicodeFonts;
-use ratatui::{prelude::*, text::StyledGrapheme, widgets::Widget};
+use ratatui_core::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::Style,
+    text::{Line, StyledGrapheme},
+    widgets::Widget,
+};
 
 use crate::PixelSize;
 
@@ -201,6 +207,7 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: &Pixel
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui_core::style::Stylize;
 
     #[test]
     fn build() {

--- a/tui-box-text/Cargo.toml
+++ b/tui-box-text/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 [dependencies]
 color-eyre.workspace = true
 indoc.workspace = true
-ratatui.workspace = true
+ratatui-core.workspace = true
 
 [dev-dependencies]
 ratatui = { workspace = true, default-features = true }

--- a/tui-box-text/src/lib.rs
+++ b/tui-box-text/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, iter::zip, sync::LazyLock};
 
-use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+use ratatui_core::{buffer::Buffer, layout::Rect, widgets::Widget};
 
 pub struct BoxChar(char);
 

--- a/tui-cards/Cargo.toml
+++ b/tui-cards/Cargo.toml
@@ -17,7 +17,7 @@ keywords.workspace = true
 color-eyre.workspace = true
 indoc.workspace = true
 strum.workspace = true
-ratatui.workspace = true
+ratatui-core.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -21,7 +21,9 @@
 use std::iter::zip;
 
 use indoc::indoc;
-use ratatui::{
+use ratatui_core::{
+    buffer::Buffer,
+    layout::Rect,
     style::{Color, Stylize},
     widgets::Widget,
 };
@@ -281,7 +283,7 @@ impl Rank {
 }
 
 impl Widget for &Card {
-    fn render(self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer)
+    fn render(self, area: Rect, buf: &mut Buffer)
     where
         Self: Sized,
     {

--- a/tui-popup/src/popup.rs
+++ b/tui-popup/src/popup.rs
@@ -86,13 +86,13 @@ impl<'content, W: SizedWidgetRef> Popup<'content, W> {
     }
 }
 
-impl SizedWidgetRef for Text<'_> {
+impl SizedWidgetRef for &Text<'_> {
     fn width(&self) -> usize {
-        self.width()
+        Text::width(self)
     }
 
     fn height(&self) -> usize {
-        self.height()
+        Text::height(self)
     }
 }
 
@@ -178,7 +178,7 @@ impl<W: SizedWidgetRef> StatefulWidgetRef for Popup<'_, W> {
             .border_style(self.border_style)
             .title(self.title.clone())
             .style(self.style);
-        block.render_ref(area, buf);
+        Widget::render(&block, area, buf);
         self.body.render_ref(block.inner(area), buf);
     }
 }

--- a/tui-scrollview/Cargo.toml
+++ b/tui-scrollview/Cargo.toml
@@ -13,7 +13,8 @@ rust-version.workspace = true
 
 [dependencies]
 indoc.workspace = true
-ratatui.workspace = true
+ratatui-core.workspace = true
+ratatui-widgets.workspace = true
 rstest.workspace = true
 
 [dev-dependencies]

--- a/tui-scrollview/examples/scrollview.rs
+++ b/tui-scrollview/examples/scrollview.rs
@@ -184,6 +184,6 @@ const CHART_DATA: [(&str, u64, Color); 3] = [
 
 fn bars() -> BarGroup<'static> {
     let data = CHART_DATA
-        .map(|(label, value, color)| Bar::default().label(label.into()).value(value).style(color));
+        .map(|(label, value, color)| Bar::default().label(label).value(value).style(color));
     BarGroup::default().bars(&data)
 }

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -1,4 +1,10 @@
-use ratatui::{layout::Size, prelude::*, widgets::*};
+use ratatui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    layout::Size,
+    widgets::{StatefulWidget, Widget},
+};
+use ratatui_widgets::scrollbar::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 use crate::ScrollViewState;
 
@@ -340,6 +346,7 @@ impl ScrollView {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui_core::text::Span;
     use rstest::{fixture, rstest};
 
     /// Initialize a buffer and a scroll view with a buffer size of 10x10

--- a/tui-scrollview/src/state.rs
+++ b/tui-scrollview/src/state.rs
@@ -1,4 +1,4 @@
-use ratatui::layout::{Position, Size};
+use ratatui_core::layout::{Position, Size};
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ScrollViewState {


### PR DESCRIPTION
See <https://github.com/ratatui/ratatui/issues/1388> for details

For now this omits tui-prompts due to Frame not being available in -core
see <https://github.com/ratatui/ratatui/issues/1388#issuecomment-2504971564>

Will do tui-popup in its own PR as it's a bit more complex due to reliance on WidgetRef.