### PR TITLE
chore: revert ratatui-0.30 changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,13 @@ derive-getters = "0.5.0"
 derive_setters = "0.1.6"
 document-features = "0.2.10"
 futures = "0.3.31"
-itertools = "0.13.0"
+itertools = "0.14.0"
 indoc = "2.0.5"
 lipsum = "0.9.1"
 pretty_assertions = "1.4.1"
-ratatui = { version = "0.30.0-alpha.0", default-features = false }
-ratatui-core = { version = "0.1.0-alpha.0" }
-ratatui-macros = "0.7.0-alpha.0"
-ratatui-widgets = { version = "0.3.0-alpha.0" }
-rstest = "0.23.0"
+ratatui = { version = "0.29.0", default-features = false }
+ratatui-macros = "0.6.0"
+rstest = "0.24.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.41.0" }
 

--- a/tui-big-text/Cargo.toml
+++ b/tui-big-text/Cargo.toml
@@ -16,13 +16,12 @@ rust-version.workspace = true
 derive_builder.workspace = true
 font8x8 = "0.3.1"
 itertools.workspace = true
-ratatui-core.workspace = true
+ratatui = { workspace = true, features = ["crossterm"] }
 
 [dev-dependencies]
 color-eyre.workspace = true
 crossterm = { workspace = true, features = ["event-stream"] }
 futures.workspace = true
 indoc.workspace = true
-ratatui = { workspace = true, features = ["crossterm"] }
 strum.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use derive_builder::Builder;
 use font8x8::UnicodeFonts;
-use ratatui_core::{
+use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
     style::Style,
@@ -206,7 +206,7 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: &Pixel
 
 #[cfg(test)]
 mod tests {
-    use ratatui_core::style::Stylize;
+    use ratatui::style::Stylize;
 
     use super::*;
 

--- a/tui-box-text/Cargo.toml
+++ b/tui-box-text/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 [dependencies]
 color-eyre.workspace = true
 indoc.workspace = true
-ratatui-core.workspace = true
+ratatui = { workspace = true, default-features = true }
 
 [dev-dependencies]
 ratatui = { workspace = true, default-features = true }

--- a/tui-box-text/src/lib.rs
+++ b/tui-box-text/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, iter::zip, sync::LazyLock};
 
-use ratatui_core::{buffer::Buffer, layout::Rect, widgets::Widget};
+use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
 
 pub struct BoxChar(char);
 

--- a/tui-cards/Cargo.toml
+++ b/tui-cards/Cargo.toml
@@ -17,8 +17,8 @@ keywords.workspace = true
 color-eyre.workspace = true
 indoc.workspace = true
 strum.workspace = true
-ratatui-core.workspace = true
 itertools.workspace = true
+ratatui = { workspace = true }
 
 [dev-dependencies]
 ratatui = { workspace = true, default-features = true }

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -21,7 +21,7 @@
 use std::iter::zip;
 
 use indoc::indoc;
-use ratatui_core::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Stylize},

--- a/tui-popup/examples/paragraph.rs
+++ b/tui-popup/examples/paragraph.rs
@@ -49,7 +49,7 @@ impl App {
         let lines: Text = (0..10).map(|i| Span::raw(format!("Line {i}"))).collect();
         let paragraph = Paragraph::new(lines).scroll((self.scroll, 0));
         let wrapper = KnownSizeWrapper {
-            inner: &paragraph,
+            inner: paragraph,
             width: 21,
             height: 5,
         };

--- a/tui-popup/examples/state.rs
+++ b/tui-popup/examples/state.rs
@@ -52,7 +52,7 @@ fn render_popup(frame: &mut Frame, area: Rect, state: &mut PopupState) {
         "h: move left",
         "l: move right",
     ]);
-    let popup = Popup::new(&body)
+    let popup = Popup::new(body)
         .title("Popup")
         .style(Style::new().white().on_blue());
     frame.render_stateful_widget(popup, area, state);

--- a/tui-scrollview/Cargo.toml
+++ b/tui-scrollview/Cargo.toml
@@ -13,8 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 indoc.workspace = true
-ratatui-core.workspace = true
-ratatui-widgets.workspace = true
+ratatui = { workspace = true }
 
 [dev-dependencies]
 color-eyre.workspace = true

--- a/tui-scrollview/examples/scrollview.rs
+++ b/tui-scrollview/examples/scrollview.rs
@@ -184,6 +184,6 @@ const CHART_DATA: [(&str, u64, Color); 3] = [
 
 fn bars() -> BarGroup<'static> {
     let data = CHART_DATA
-        .map(|(label, value, color)| Bar::default().label(label).value(value).style(color));
+        .map(|(label, value, color)| Bar::default().label(label.into()).value(value).style(color));
     BarGroup::default().bars(&data)
 }

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -1,9 +1,8 @@
-use ratatui_core::{
+use ratatui::{
     buffer::Buffer,
     layout::{Rect, Size},
-    widgets::{StatefulWidget, Widget},
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget},
 };
-use ratatui_widgets::scrollbar::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 
 use crate::ScrollViewState;
 
@@ -344,7 +343,7 @@ impl ScrollView {
 
 #[cfg(test)]
 mod tests {
-    use ratatui_core::text::Span;
+    use ratatui::text::Span;
     use rstest::{fixture, rstest};
 
     use super::*;

--- a/tui-scrollview/src/state.rs
+++ b/tui-scrollview/src/state.rs
@@ -1,4 +1,4 @@
-use ratatui_core::layout::{Position, Size};
+use ratatui::layout::{Position, Size};
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ScrollViewState {


### PR DESCRIPTION
Reverting the main branch back to tracking the release version of Ratatui so that I can release changes to stable widgets and work on the ratatui-0.30 widgets in another branch. https://github.com/joshka/tui-widgets/tree/ratatui-0.30
