### PR TITLE
feat: Implement interactive popup dragging and resizing

### DIFF
--- a/tui-popup/Cargo.toml
+++ b/tui-popup/Cargo.toml
@@ -53,3 +53,7 @@ required-features = ["crossterm"]
 [[example]]
 name = "state"
 required-features = ["crossterm"]
+
+[[example]]
+name = "interactive"
+required-features = ["crossterm"]

--- a/tui-popup/examples/interactive.rs
+++ b/tui-popup/examples/interactive.rs
@@ -1,0 +1,127 @@
+use std::io::{self, stdout};
+
+use color_eyre::Result;
+use ratatui::{
+    crossterm::{self, event::{DisableMouseCapture, EnableMouseCapture}, execute, terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen}},
+    prelude::{Constraint, CrosstermBackend, Frame, Layout, Rect, Style, Stylize},
+    widgets::{Paragraph, Wrap},
+    DefaultTerminal, Terminal,
+};
+use tui_popup::{KnownSizeWrapper, Popup, PopupState};
+
+fn set_panic_hook() {
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore();
+        hook(info);
+    }));
+}
+
+pub fn try_init() -> io::Result<DefaultTerminal> {
+    set_panic_hook();
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout());
+    Terminal::new(backend)
+}
+
+pub fn init() -> DefaultTerminal {
+    try_init().expect("failed to initialize terminal")
+}
+
+pub fn try_restore() -> io::Result<()> {
+    // disabling raw mode first is important as it has more side effects than leaving the alternate
+    // screen buffer
+    disable_raw_mode()?;
+    execute!(stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+    Ok(())
+}
+
+pub fn restore() {
+    if let Err(err) = try_restore() {
+        // There's not much we can do if restoring the terminal fails, so we just print the error
+        eprintln!("Failed to restore terminal: {err}");
+    }
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let terminal = init();
+    let result = run(terminal);
+    restore();
+    result
+}
+
+fn run(mut terminal: DefaultTerminal) -> Result<()> {
+    let (width, height) = crossterm::terminal::size()?;
+    let mut state = PopupState::new(Rect::new(0, 0, width, height));
+    let mut exit = false;
+    while !exit {
+        // Update terminal size on every frame to handle terminal resizing
+        if let Ok((width, height)) = crossterm::terminal::size() {
+            state.set_terminal_size(Rect::new(0, 0, width, height));
+        }
+        terminal.draw(|frame| draw(frame, &mut state))?;
+        handle_events(&mut state, &mut exit)?;
+    }
+    Ok(())
+}
+
+fn draw(frame: &mut Frame, state: &mut PopupState) {
+    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]);
+    let [background_area, status_area] = vertical.areas(frame.area());
+
+    render_background(frame, background_area);
+    render_popup(frame, background_area, state);
+    render_status_bar(frame, status_area, state);
+}
+
+fn render_background(frame: &mut Frame, area: Rect) {
+    let background = Paragraph::new("Background content - click and drag the popup to move it!")
+        .style(Style::default().dark_gray());
+    frame.render_widget(background, area);
+}
+
+fn render_popup(frame: &mut Frame, area: Rect, state: &mut PopupState) {
+    let content = "This is an interactive popup example!\n\
+                    \n\
+                    • Drag the popup by clicking and dragging anywhere inside it\n\
+                    • Resize by dragging the ▢ handle in the bottom-right corner\n\
+                    • Press 'q' to exit";
+
+    let wrapped_content =
+        KnownSizeWrapper::new(Paragraph::new(content).wrap(Wrap { trim: true }), 40, 6);
+
+    let popup = Popup::new(wrapped_content)
+        .title("Interactive Popup")
+        .border_style(Style::default().blue().bold());
+
+    frame.render_stateful_widget(popup, area, state);
+}
+
+/// Status bar at the bottom of the screen
+///
+/// Must be called after rendering the popup widget as it relies on the popup area being set
+fn render_status_bar(frame: &mut Frame, area: Rect, state: &mut PopupState) {
+    let popup_area = state.area().unwrap_or_default();
+    let text = format!("Popup area: {popup_area:?}");
+    let paragraph = Paragraph::new(text).style(Style::new().white().on_black());
+    frame.render_widget(paragraph, area);
+}
+
+fn handle_events(popup: &mut PopupState, exit: &mut bool) -> Result<()> {
+    if let Ok(event) = crossterm::event::read() {
+        match event {
+            crossterm::event::Event::Key(key) => {
+                if key.code == crossterm::event::KeyCode::Char('q') {
+                    *exit = true;
+                }
+            }
+            crossterm::event::Event::Mouse(event) => {
+                popup.handle_mouse_event(event);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/tui-popup/src/lib.rs
+++ b/tui-popup/src/lib.rs
@@ -30,5 +30,5 @@ pub use crate::{
     known_size::KnownSize,
     known_size_wrapper::KnownSizeWrapper,
     popup::Popup,
-    popup_state::{DragState, PopupState},
+    popup_state::{InteractionState, PopupState},
 };

--- a/tui-popup/src/popup_state.rs
+++ b/tui-popup/src/popup_state.rs
@@ -3,25 +3,56 @@ use derive_getters::Getters;
 use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::prelude::Rect;
 
+/// Minimum dimensions for a popup
+const MIN_WIDTH: u16 = 3;
+const MIN_HEIGHT: u16 = 3;
+
 #[derive(Clone, Debug, Default, Getters)]
 pub struct PopupState {
     /// The last rendered area of the popup
     pub(crate) area: Option<Rect>,
-    /// A state indicating whether the popup is being dragged or not
-    pub(crate) drag_state: DragState,
+    /// A state indicating whether the popup is being dragged or resized
+    pub(crate) interaction_state: InteractionState,
+    /// The current terminal size
+    terminal_size: Option<Rect>,
 }
 
 #[derive(Clone, Debug, Default)]
-pub enum DragState {
+pub enum InteractionState {
     #[default]
-    NotDragging,
+    None,
     Dragging {
         col_offset: u16,
         row_offset: u16,
     },
+    Resizing {
+        start_width: u16,
+        start_height: u16,
+        start_x: u16,
+        start_y: u16,
+    },
 }
 
 impl PopupState {
+    /// Create a new popup state with the given terminal size
+    #[must_use]
+    pub const fn new(terminal_size: Rect) -> Self {
+        Self {
+            area: None,
+            interaction_state: InteractionState::None,
+            terminal_size: Some(terminal_size),
+        }
+    }
+
+    /// Update the terminal size
+    pub fn set_terminal_size(&mut self, size: Rect) {
+        self.terminal_size = Some(size);
+        // Ensure popup stays within new bounds
+        if let Some(area) = self.area {
+            self.area = Some(self.constrain_to_terminal(area));
+        }
+    }
+
     pub fn move_up(&mut self, amount: u16) {
         self.move_by(0, -i32::from(amount));
     }
@@ -62,11 +93,49 @@ impl PopupState {
         }
     }
 
-    /// Set the state to dragging if the mouse click is in the popup title
+    /// Constrain a rectangle to fit within terminal bounds while maintaining minimum size
+    fn constrain_to_terminal(&self, mut rect: Rect) -> Rect {
+        let terminal = self
+            .terminal_size
+            .unwrap_or(Rect::new(0, 0, u16::MAX, u16::MAX));
+
+        // Enforce minimum size
+        rect.width = rect.width.max(MIN_WIDTH);
+        rect.height = rect.height.max(MIN_HEIGHT);
+
+        // Constrain size to terminal bounds
+        rect.width = rect.width.min(terminal.width);
+        rect.height = rect.height.min(terminal.height);
+
+        // Adjust position to keep popup within bounds
+        if rect.x + rect.width > terminal.width {
+            rect.x = terminal.width.saturating_sub(rect.width);
+        }
+        if rect.y + rect.height > terminal.height {
+            rect.y = terminal.height.saturating_sub(rect.height);
+        }
+
+        rect
+    }
+
+    /// Check if the given position is on the resize handle
+    fn is_on_resize_handle(&self, col: u16, row: u16) -> bool {
+        self.area
+            .is_some_and(|area| col == area.x + area.width - 1 && row == area.y + area.height - 1)
+    }
+
+    /// Set the state to dragging or resizing if the mouse click is in the popup title or on the resize handle
     pub fn mouse_down(&mut self, col: u16, row: u16) {
         if let Some(area) = self.area {
-            if area.contains((col, row).into()) {
-                self.drag_state = DragState::Dragging {
+            if self.is_on_resize_handle(col, row) {
+                self.interaction_state = InteractionState::Resizing {
+                    start_width: area.width,
+                    start_height: area.height,
+                    start_x: col,
+                    start_y: row,
+                };
+            } else if area.contains((col, row).into()) {
+                self.interaction_state = InteractionState::Dragging {
                     col_offset: col.saturating_sub(area.x),
                     row_offset: row.saturating_sub(area.y),
                 };
@@ -74,23 +143,82 @@ impl PopupState {
         }
     }
 
-    /// Set the state to not dragging
+    /// Set the state to not dragging or resizing
     pub fn mouse_up(&mut self, _col: u16, _row: u16) {
-        self.drag_state = DragState::NotDragging;
+        self.interaction_state = InteractionState::None;
     }
 
-    /// Move the popup if the state is dragging
+    /// Handle mouse drag events during resize
+    fn handle_resize(&self, col: u16, row: u16, start: (u16, u16, u16, u16)) -> Rect {
+        let (start_width, start_height, start_x, start_y) = start;
+        let area = self.area.unwrap();
+
+        // Convert to signed integers for safe arithmetic
+        let start_x = i32::from(start_x);
+        let start_y = i32::from(start_y);
+        let col = i32::from(col);
+        let row = i32::from(row);
+
+        // Calculate size changes, handling both positive and negative deltas
+        let width_delta = col - start_x;
+        let height_delta = row - start_y;
+
+        println!(
+            "col: {}, start_x: {}, width_delta: {}",
+            col, start_x, width_delta
+        );
+        println!(
+            "start_width: {}, new calculated width: {}",
+            start_width,
+            i32::from(start_width) + width_delta
+        );
+
+        // Calculate new dimensions, ensuring we don't go below minimum size
+        let new_width = u16::try_from(
+            (i32::from(start_width) + width_delta)
+                .max(i32::from(MIN_WIDTH))
+                .min(i32::from(self.terminal_size.unwrap_or_default().width)),
+        )
+        .unwrap_or(MIN_WIDTH);
+
+        let new_height = u16::try_from(
+            (i32::from(start_height) + height_delta)
+                .max(i32::from(MIN_HEIGHT))
+                .min(i32::from(self.terminal_size.unwrap_or_default().height)),
+        )
+        .unwrap_or(MIN_HEIGHT);
+
+        // Create new rect and constrain it
+        let new_rect = Rect {
+            width: new_width,
+            height: new_height,
+            ..area
+        };
+
+        self.constrain_to_terminal(new_rect)
+    }
+
+    /// Move or resize the popup if the state is dragging or resizing
     pub fn mouse_drag(&mut self, col: u16, row: u16) {
-        if let DragState::Dragging {
-            col_offset,
-            row_offset,
-        } = self.drag_state
-        {
-            if let Some(area) = self.area {
-                let x = col.saturating_sub(col_offset);
-                let y = row.saturating_sub(row_offset);
-                self.area.replace(Rect { x, y, ..area });
-            }
+        if let Some(area) = self.area {
+            let new_area = match self.interaction_state {
+                InteractionState::Dragging {
+                    col_offset,
+                    row_offset,
+                } => {
+                    let x = col.saturating_sub(col_offset);
+                    let y = row.saturating_sub(row_offset);
+                    self.constrain_to_terminal(Rect { x, y, ..area })
+                }
+                InteractionState::Resizing {
+                    start_width,
+                    start_height,
+                    start_x,
+                    start_y,
+                } => self.handle_resize(col, row, (start_width, start_height, start_x, start_y)),
+                InteractionState::None => area,
+            };
+            self.area = Some(new_area);
         }
     }
 
@@ -102,5 +230,90 @@ impl PopupState {
             MouseEventKind::Drag(MouseButton::Left) => self.mouse_drag(event.column, event.row),
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resize_constraints() {
+        let mut state = PopupState::new(Rect::new(0, 0, 80, 24));
+        state.area = Some(Rect::new(10, 10, 20, 10));
+
+        // Test resize with valid dimensions
+        state.interaction_state = InteractionState::Resizing {
+            start_width: 20,
+            start_height: 10,
+            start_x: 29,
+            start_y: 20,
+        };
+
+        // Move mouse to x=25, y=15
+        // Width delta = 25 - 29 = -4, so new width = 20 + (-4) = 16
+        state.mouse_drag(25, 15);
+        let area = state.area.unwrap();
+        assert_eq!(
+            area.width, 16,
+            "Width should be start_width + delta = 20 + (25-29) = 16"
+        );
+        assert_eq!(
+            area.height, 5,
+            "Height should be start_height + (row - start_y) = 10 + (15-20) = 5"
+        );
+
+        // Test significant resize reduction
+        // Moving to x=20 means delta = 20 - 29 = -9, so width = 20 + (-9) = 11
+        state.mouse_drag(20, 10);
+        let area = state.area.unwrap();
+        assert_eq!(
+            area.width, 11,
+            "Width should be start_width + delta = 20 + (20-29) = 11"
+        );
+        assert_eq!(
+            area.height, MIN_HEIGHT,
+            "Height should be clamped to MIN_HEIGHT"
+        );
+
+        // Move even further to test terminal boundary constraint
+        state.mouse_drag(90, 30);
+        let area = state.area.unwrap();
+        assert!(area.right() <= 80);
+        assert!(area.bottom() <= 24);
+    }
+
+    #[test]
+    fn test_drag_constraints() {
+        let mut state = PopupState::new(Rect::new(0, 0, 80, 24));
+        state.area = Some(Rect::new(10, 10, 20, 10));
+
+        // Test dragging within bounds
+        state.interaction_state = InteractionState::Dragging {
+            col_offset: 5,
+            row_offset: 5,
+        };
+        state.mouse_drag(15, 15);
+        let area = state.area.unwrap();
+        assert!(area.x <= 80 - area.width);
+        assert!(area.y <= 24 - area.height);
+
+        // Test dragging against terminal edges
+        state.mouse_drag(90, 30);
+        let area = state.area.unwrap();
+        assert!(area.right() <= 80);
+        assert!(area.bottom() <= 24);
+    }
+
+    #[test]
+    fn test_terminal_resize() {
+        let mut state = PopupState::new(Rect::new(0, 0, 80, 24));
+        state.area = Some(Rect::new(70, 20, 20, 10));
+
+        // Simulate terminal getting smaller
+        state.set_terminal_size(Rect::new(0, 0, 60, 15));
+        let area = state.area.unwrap();
+        assert!(area.right() <= 60);
+        assert!(area.bottom() <= 15);
     }
 }


### PR DESCRIPTION
This commit introduces interactive dragging and resizing functionality to the `tui-popup` crate.

Changes include:

- Added an `interactive` example demonstrating the new features.
- Updated `PopupState` to manage interaction state (dragging and resizing).
- Modified `Popup` widget to render a resize handle.
- Implemented mouse event handling for dragging and resizing.
- Added constraints to keep the popup within terminal bounds and enforce minimum size.

These changes allow users to interactively reposition and resize popups within the terminal, improving the user experience.