### PR TITLE
Added render_stateful_widget method to ScrollView

### DIFF
--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -780,4 +780,28 @@ mod tests {
             ])
         )
     }
+
+    #[rstest]
+    #[rustfmt::skip]
+    fn render_stateful_widget(mut scroll_view: ScrollView) {
+        use ratatui::widgets::{List, ListState};
+        scroll_view = scroll_view.horizontal_scrollbar_visibility(ScrollbarVisibility::Never);
+        let mut buf = Buffer::empty(Rect::new(0, 0, 7, 5));
+        let mut state = ScrollViewState::default();
+        let mut list_state = ListState::default();
+        let items: Vec<String> = (1..=10).map(|i| format!("Item {}", i)).collect();
+        let list = List::new(items);
+        scroll_view.render_stateful_widget(list, scroll_view.area(), &mut list_state);
+        scroll_view.render(buf.area, &mut buf, &mut state);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(vec![
+                "Item 1▲",
+                "Item 2█",
+                "Item 3█",
+                "Item 4║",
+                "Item 5▼",
+            ])
+        )
+    }
 }

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -187,6 +187,24 @@ impl ScrollView {
     pub fn render_widget<W: Widget>(&mut self, widget: W, area: Rect) {
         widget.render(area, &mut self.buf);
     }
+
+    /// Render a stateful widget into the scroll buffer
+    ///
+    /// This is the equivalent of `Frame::render_stateful_widget`, but renders the stateful widget
+    /// into the scroll buffer rather than the main buffer. The stateful widget will be rendered
+    /// into the area of the buffer specified by the `area` parameter.
+    ///
+    /// This should not be confused with the `render` method, which renders the visible area of the
+    /// ScrollView into the main buffer.
+
+    pub fn render_stateful_widget<W: StatefulWidget>(
+        &mut self,
+        widget: W,
+        area: Rect,
+        state: &mut W::State,
+    ) {
+        widget.render(area, &mut self.buf, state);
+    }
 }
 
 impl StatefulWidget for ScrollView {


### PR DESCRIPTION
The render_stateful_widget method has been added to ScrollView, allowing ScrollView to work with a stateful widget.