### PR TITLE
bump msrv to 1.82.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,4 +11,4 @@ jobs:
       checks: write
     uses: joshka/github-workflows/.github/workflows/rust-check.yml@main
     with:
-      msrv: 1.80.0
+      msrv: 1.82.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Joshka"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshka/tui-widgets"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 categories = ["command-line-interface", "gui"]
 keywords = ["cli", "console", "ratatui", "terminal", "tui"]
 

--- a/tui-bar-graph/src/lib.rs
+++ b/tui-bar-graph/src/lib.rs
@@ -233,7 +233,9 @@ impl BarGraph {
                 .ceil() as usize;
 
             for (row_index, row) in column.rows().rev().enumerate().take(column_height) {
-                let value = f64::midpoint(left_value, right_value);
+                // TODO midpoint is stablized in 1.87 https://github.com/rust-lang/rust/pull/134340
+                // let value = f64::midpoint(left_value, right_value);
+                let value = (left_value + right_value) / 2.0;
                 let color = self.color_for(area, min, max, value, row_index);
 
                 let dots_below = row_index * DOTS_PER_ROW;


### PR DESCRIPTION
backtrace@0.3.75 requires rustc 1.82.0
