### PR TITLE
feat: Query if ScrollViewState is_at_bottom()

### DIFF
--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -234,16 +234,8 @@ impl StatefulWidget for ScrollView {
         // `saturating_sub` covers both "content smaller than viewport" and zero-sized viewport
         // cases. Zero-sized areas later panic while rendering scrollbars, matching existing
         // behavior, but this arithmetic still must not wrap before that boundary.
-        let max_x_offset = self
-            .buf
-            .area
-            .width
-            .saturating_sub(viewport_width);
-        let max_y_offset = self
-            .buf
-            .area
-            .height
-            .saturating_sub(viewport_height);
+        let max_x_offset = self.buf.area.width.saturating_sub(viewport_width);
+        let max_y_offset = self.buf.area.height.saturating_sub(viewport_height);
 
         x = x.min(max_x_offset);
         y = y.min(max_y_offset);
@@ -567,6 +559,143 @@ mod tests {
         );
         assert_eq!(state.offset.y, 4);
         assert_eq!(state.page_size.unwrap().height, 6);
+    }
+
+    #[rstest]
+    #[case::always_always(
+        ScrollbarVisibility::Always,
+        ScrollbarVisibility::Always,
+        1,
+        1,
+        (true, true)
+    )]
+    #[case::never_never(
+        ScrollbarVisibility::Never,
+        ScrollbarVisibility::Never,
+        -1,
+        -1,
+        (false, false)
+    )]
+    #[case::always_never(
+        ScrollbarVisibility::Always,
+        ScrollbarVisibility::Never,
+        1,
+        1,
+        (true, false)
+    )]
+    #[case::never_always(
+        ScrollbarVisibility::Never,
+        ScrollbarVisibility::Always,
+        1,
+        1,
+        (false, true)
+    )]
+    #[case::automatic_never_needs_horizontal(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Never,
+        -1,
+        1,
+        (true, false)
+    )]
+    #[case::automatic_never_fits_horizontal(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Never,
+        1,
+        -1,
+        (false, false)
+    )]
+    #[case::never_automatic_needs_vertical(
+        ScrollbarVisibility::Never,
+        ScrollbarVisibility::Automatic,
+        1,
+        -1,
+        (false, true)
+    )]
+    #[case::never_automatic_fits_vertical(
+        ScrollbarVisibility::Never,
+        ScrollbarVisibility::Automatic,
+        -1,
+        1,
+        (false, false)
+    )]
+    #[case::always_automatic_exact_fit(
+        ScrollbarVisibility::Always,
+        ScrollbarVisibility::Automatic,
+        1,
+        0,
+        (true, true)
+    )]
+    #[case::always_automatic_vertical_fits(
+        ScrollbarVisibility::Always,
+        ScrollbarVisibility::Automatic,
+        1,
+        1,
+        (true, false)
+    )]
+    #[case::automatic_always_exact_fit(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Always,
+        0,
+        1,
+        (true, true)
+    )]
+    #[case::automatic_always_horizontal_fits(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Always,
+        1,
+        1,
+        (false, true)
+    )]
+    #[case::automatic_automatic_both_fit(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Automatic,
+        1,
+        1,
+        (false, false)
+    )]
+    #[case::automatic_automatic_both_overflow(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Automatic,
+        -1,
+        -1,
+        (true, true)
+    )]
+    #[case::automatic_automatic_only_vertical_overflows(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Automatic,
+        1,
+        -1,
+        (false, true)
+    )]
+    #[case::automatic_automatic_only_horizontal_overflows(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Automatic,
+        -1,
+        1,
+        (true, false)
+    )]
+    #[case::automatic_automatic_exact_fit_with_other_overflow(
+        ScrollbarVisibility::Automatic,
+        ScrollbarVisibility::Automatic,
+        0,
+        -1,
+        (true, true)
+    )]
+    fn visible_scrollbars_honors_visibility_policy(
+        #[case] horizontal_visibility: ScrollbarVisibility,
+        #[case] vertical_visibility: ScrollbarVisibility,
+        #[case] horizontal_space: i32,
+        #[case] vertical_space: i32,
+        #[case] expected: (bool, bool),
+    ) {
+        let scroll_view = ScrollView::new(Size::new(1, 1))
+            .horizontal_scrollbar_visibility(horizontal_visibility)
+            .vertical_scrollbar_visibility(vertical_visibility);
+
+        assert_eq!(
+            scroll_view.visible_scrollbars(horizontal_space, vertical_space),
+            expected
+        );
     }
 
     #[rstest]

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -457,6 +457,28 @@ mod tests {
     }
 
     #[rstest]
+    fn is_at_bottom_reports_true_before_the_last_row_is_visible(scroll_view: ScrollView) {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
+        let mut state = ScrollViewState::with_offset((0, 4).into());
+
+        scroll_view.render(buf.area, &mut buf, &mut state);
+
+        assert_eq!(
+            buf,
+            Buffer::with_lines(vec![
+                "OPQRS▲",
+                "YZABC║",
+                "IJKLM█",
+                "STUVW█",
+                "CDEFG▼",
+                "◄██═► ",
+            ])
+        );
+        // Incorrect behavior: the final row is not rendered yet.
+        assert!(state.is_at_bottom());
+    }
+
+    #[rstest]
     fn move_to_bottom(scroll_view: ScrollView) {
         let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
         let mut state = ScrollViewState::default();
@@ -482,6 +504,7 @@ mod tests {
 
         // we reach the bottom,
         assert!(state.is_at_bottom());
+        // Incorrect behavior: this offset scrolls past the last full page.
         assert_eq!(state.offset.y, 5);
 
         // and we see the last five rows of the content.
@@ -505,6 +528,29 @@ mod tests {
         // ...which sets the offset to the last row of content,
         // ensuring to be at the bottom regardless of the page size.
         assert_eq!(state.offset.y, state.size.unwrap().height - 1);
+    }
+
+    #[rstest]
+    fn rendering_at_bottom_scrolls_past_the_last_full_page(scroll_view: ScrollView) {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 11, 6));
+        let mut state = ScrollViewState::default();
+
+        state.scroll_to_bottom();
+        scroll_view.render(buf.area, &mut buf, &mut state);
+
+        assert_eq!(
+            buf,
+            Buffer::with_lines(vec![
+                "YZABCDEFGH▲",
+                "IJKLMNOPQR║",
+                "STUVWXYZAB█",
+                "CDEFGHIJKL█",
+                "MNOPQRSTUV█",
+                "          ▼",
+            ])
+        );
+        assert_eq!(state.offset.y, 5);
+        assert_eq!(state.page_size.unwrap().height, 6);
     }
 
     #[rstest]

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -198,7 +198,6 @@ impl ScrollView {
     ///
     /// This should not be confused with the `render` method, which renders the visible area of the
     /// ScrollView into the main buffer.
-
     pub fn render_stateful_widget<W: StatefulWidget>(
         &mut self,
         widget: W,
@@ -214,26 +213,45 @@ impl StatefulWidget for ScrollView {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let (mut x, mut y) = state.offset.into();
-        // ensure that we don't scroll past the end of the buffer in either direction
+        let horizontal_space = area.width as i32 - self.size.width as i32;
+        let vertical_space = area.height as i32 - self.size.height as i32;
+        let (show_horizontal, show_vertical) =
+            self.visible_scrollbars(horizontal_space, vertical_space);
+
+        // Scrollbars steal space from the viewport. Clamp offsets against that final viewport,
+        // not the raw render area, so the bottom position is the last full page of content.
+        let viewport_width = area.width.saturating_sub(show_vertical as u16);
+        let viewport_height = area.height.saturating_sub(show_horizontal as u16);
+
+        // If the content fits in a direction, discard any stale offset for that direction.
+        if horizontal_space > 0 {
+            x = 0;
+        }
+        if vertical_space > 0 {
+            y = 0;
+        }
+
+        // `saturating_sub` covers both "content smaller than viewport" and zero-sized viewport
+        // cases. Zero-sized areas later panic while rendering scrollbars, matching existing
+        // behavior, but this arithmetic still must not wrap before that boundary.
         let max_x_offset = self
             .buf
             .area
             .width
-            .saturating_sub(area.width.saturating_sub(1));
+            .saturating_sub(viewport_width);
         let max_y_offset = self
             .buf
             .area
             .height
-            .saturating_sub(area.height.saturating_sub(1));
+            .saturating_sub(viewport_height);
 
         x = x.min(max_x_offset);
         y = y.min(max_y_offset);
         state.offset = (x, y).into();
         state.size = Some(self.size);
-        state.page_size = Some(area.into());
-        let visible_area = self
-            .render_scrollbars(area, buf, state)
-            .intersection(self.buf.area);
+        let viewport_area = self.render_scrollbars(area, buf, state);
+        state.page_size = Some(viewport_area.as_size());
+        let visible_area = viewport_area.intersection(self.buf.area);
         self.render_visible_area(area, buf, visible_area);
     }
 }
@@ -249,7 +267,7 @@ impl ScrollView {
         let horizontal_space = area.width as i32 - self.size.width as i32;
         let vertical_space = area.height as i32 - self.size.height as i32;
 
-        // if it fits in that direction, reset state to reflect it
+        // If the content fits in a direction, reset state to reflect it.
         if horizontal_space > 0 {
             state.offset.x = 0;
         }
@@ -457,7 +475,7 @@ mod tests {
     }
 
     #[rstest]
-    fn is_at_bottom_reports_true_before_the_last_row_is_visible(scroll_view: ScrollView) {
+    fn is_not_at_bottom_until_the_last_row_is_visible(scroll_view: ScrollView) {
         let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
         let mut state = ScrollViewState::with_offset((0, 4).into());
 
@@ -474,8 +492,7 @@ mod tests {
                 "◄██═► ",
             ])
         );
-        // Incorrect behavior: the final row is not rendered yet.
-        assert!(state.is_at_bottom());
+        assert!(!state.is_at_bottom());
     }
 
     #[rstest]
@@ -483,13 +500,13 @@ mod tests {
         let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
         let mut state = ScrollViewState::default();
 
-        // Prior rendering, page and buffer size are unkown. We default to `true`.
+        // Prior to rendering, page and buffer size are unknown. We default to `true`.
         assert!(state.is_at_bottom());
 
         scroll_view.clone().render(buf.area, &mut buf, &mut state);
 
         // The vertical view size is five which means the page size is five.
-        // We have not scrolled yet, view is at the top and not the at the bottom.
+        // We have not scrolled yet, so the view is at the top and not at the bottom.
         // => We see the top five rows
         assert!(!state.is_at_bottom());
 
@@ -504,7 +521,6 @@ mod tests {
 
         // we reach the bottom,
         assert!(state.is_at_bottom());
-        // Incorrect behavior: this offset scrolls past the last full page.
         assert_eq!(state.offset.y, 5);
 
         // and we see the last five rows of the content.
@@ -531,7 +547,7 @@ mod tests {
     }
 
     #[rstest]
-    fn rendering_at_bottom_scrolls_past_the_last_full_page(scroll_view: ScrollView) {
+    fn rendering_at_bottom_uses_the_last_full_page(scroll_view: ScrollView) {
         let mut buf = Buffer::empty(Rect::new(0, 0, 11, 6));
         let mut state = ScrollViewState::default();
 
@@ -541,15 +557,15 @@ mod tests {
         assert_eq!(
             buf,
             Buffer::with_lines(vec![
-                "YZABCDEFGH▲",
-                "IJKLMNOPQR║",
+                "OPQRSTUVWX▲",
+                "YZABCDEFGH║",
+                "IJKLMNOPQR█",
                 "STUVWXYZAB█",
                 "CDEFGHIJKL█",
-                "MNOPQRSTUV█",
-                "          ▼",
+                "MNOPQRSTUV▼",
             ])
         );
-        assert_eq!(state.offset.y, 5);
+        assert_eq!(state.offset.y, 4);
         assert_eq!(state.page_size.unwrap().height, 6);
     }
 
@@ -893,7 +909,7 @@ mod tests {
         let items: Vec<String> = (1..=10).map(|i| format!("Item {i}")).collect();
         let list = List::new(items);
         scroll_view.render_stateful_widget(list, scroll_view.area(), &mut list_state);
-        scroll_view.clone().render(buf.area, &mut buf, &mut state);
+        scroll_view.render(buf.area, &mut buf, &mut state);
         assert_eq!(
             buf,
             Buffer::with_lines(vec![

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -198,6 +198,7 @@ impl ScrollView {
     ///
     /// This should not be confused with the `render` method, which renders the visible area of the
     /// ScrollView into the main buffer.
+
     pub fn render_stateful_widget<W: StatefulWidget>(
         &mut self,
         widget: W,
@@ -453,6 +454,57 @@ mod tests {
                 "◄██═► ",
             ])
         )
+    }
+
+    #[rstest]
+    fn move_to_bottom(scroll_view: ScrollView) {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 6, 6));
+        let mut state = ScrollViewState::default();
+
+        // Prior rendering, page and buffer size are unkown. We default to `true`.
+        assert!(state.is_at_bottom());
+
+        scroll_view.clone().render(buf.area, &mut buf, &mut state);
+
+        // The vertical view size is five which means the page size is five.
+        // We have not scrolled yet, view is at the top and not the at the bottom.
+        // => We see the top five rows
+        assert!(!state.is_at_bottom());
+
+        // Since the content height is ten,
+        assert_eq!(state.size.unwrap().height, 10);
+        // if we scroll down one page (five rows),
+        state.scroll_down();
+        state.scroll_down();
+        state.scroll_down();
+        state.scroll_down();
+        state.scroll_down();
+
+        // we reach the bottom,
+        assert!(state.is_at_bottom());
+        assert_eq!(state.offset.y, 5);
+
+        // and we see the last five rows of the content.
+        scroll_view.render(buf.area, &mut buf, &mut state);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(vec![
+                "YZABC▲",
+                "IJKLM║",
+                "STUVW█",
+                "CDEFG█",
+                "MNOPQ▼",
+                "◄██═► ",
+            ])
+        );
+
+        // We could also jump directly to the bottom...
+        state.scroll_to_bottom();
+        assert!(state.is_at_bottom());
+
+        // ...which sets the offset to the last row of content,
+        // ensuring to be at the bottom regardless of the page size.
+        assert_eq!(state.offset.y, state.size.unwrap().height - 1);
     }
 
     #[rstest]
@@ -795,7 +847,7 @@ mod tests {
         let items: Vec<String> = (1..=10).map(|i| format!("Item {i}")).collect();
         let list = List::new(items);
         scroll_view.render_stateful_widget(list, scroll_view.area(), &mut list_state);
-        scroll_view.render(buf.area, &mut buf, &mut state);
+        scroll_view.clone().render(buf.area, &mut buf, &mut state);
         assert_eq!(
             buf,
             Buffer::with_lines(vec![

--- a/tui-scrollview/src/state.rs
+++ b/tui-scrollview/src/state.rs
@@ -74,6 +74,9 @@ impl ScrollViewState {
     }
 
     /// Move the scroll view state to the bottom of the buffer
+    ///
+    /// If the buffer size is not yet computed (done during the first rendering), it will not
+    /// be taken into account and the scroll offset will be set to the maximum value: `u16::MAX`
     pub fn scroll_to_bottom(&mut self) {
         // the render call will adjust the offset to ensure that we don't scroll past the end of
         // the buffer, so we can set the offset to the maximum value here
@@ -81,5 +84,19 @@ impl ScrollViewState {
             .size
             .map_or(u16::MAX, |size| size.height.saturating_sub(1));
         self.offset.y = bottom;
+    }
+
+    /// True if the scroll view state is at the bottom of the buffer
+    ///
+    /// This takes the page size into account. It returns true if the current scroll offset plus
+    /// the page size matches or exceeds the buffer length.
+    ///
+    /// The buffer and the page size are unknown until computed during the first rendering. If the
+    /// page size is not yet known, it won't be taken into account. If the buffer is not yet known,
+    /// this function always returns true.
+    pub fn is_at_bottom(&self) -> bool {
+        let bottom = self.size.map_or(0, |size| size.height.saturating_sub(1));
+        let page_size = self.page_size.map_or(0, |size| size.height);
+        self.offset.y.saturating_add(page_size) >= bottom
     }
 }

--- a/tui-scrollview/src/state.rs
+++ b/tui-scrollview/src/state.rs
@@ -88,16 +88,22 @@ impl ScrollViewState {
 
     /// True if the scroll view state is at the bottom of the buffer
     ///
-    /// This takes the page size into account. It returns true if the current scroll offset plus
-    /// the page size matches or exceeds the buffer length.
+    /// This takes the page size into account. It returns true if the last row in the buffer is
+    /// visible in the current page.
     ///
     /// The buffer and the page size are unknown until computed during the first rendering. If the
-    /// page size is not yet known, it won't be taken into account. If the buffer is not yet known,
-    /// this function always returns true.
+    /// buffer size is not yet known, this function always returns true. If the page size is not yet
+    /// known, the current row is treated as a one-row page.
+    ///
+    /// Saturating arithmetic prevents large offsets from overflowing when they are combined with
+    /// the page size.
     pub fn is_at_bottom(&self) -> bool {
-        let bottom = self.size.map_or(0, |size| size.height.saturating_sub(1));
-        let page_size = self.page_size.map_or(0, |size| size.height);
-        self.offset.y.saturating_add(page_size) >= bottom
+        let Some(size) = self.size else {
+            return true;
+        };
+        let bottom = size.height.saturating_sub(1);
+        let page_size = self.page_size.map_or(1, |size| size.height);
+        self.offset.y.saturating_add(page_size) > bottom
     }
 }
 
@@ -106,15 +112,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_at_bottom_reports_true_before_the_last_row_is_visible() {
+    fn is_at_bottom_requires_the_last_row_to_be_visible() {
         let mut state = ScrollViewState {
             offset: Position::new(0, 4),
             size: Some(Size::new(1, 10)),
             page_size: Some(Size::new(1, 5)),
         };
 
-        // Incorrect behavior: the last row is not visible at this offset.
-        assert!(state.is_at_bottom());
+        assert!(!state.is_at_bottom());
 
         state.offset.y = 5;
 

--- a/tui-scrollview/src/state.rs
+++ b/tui-scrollview/src/state.rs
@@ -100,3 +100,24 @@ impl ScrollViewState {
         self.offset.y.saturating_add(page_size) >= bottom
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_at_bottom_reports_true_before_the_last_row_is_visible() {
+        let mut state = ScrollViewState {
+            offset: Position::new(0, 4),
+            size: Some(Size::new(1, 10)),
+            page_size: Some(Size::new(1, 5)),
+        };
+
+        // Incorrect behavior: the last row is not visible at this offset.
+        assert!(state.is_at_bottom());
+
+        state.offset.y = 5;
+
+        assert!(state.is_at_bottom());
+    }
+}


### PR DESCRIPTION
Hey 🐅,

this aims to fix #72 

It is close to what was discussed but I made the additional decision to respect the page size.
I believe this is the right way to do it as not respecting the page size feels very odd to the user, example:
```Rust
let state = ...;
// our content is 5 rows
assert_eq!(state.size.unwrap().height, 5);
// our page size is 3
assert_eq!(state.page_size.unwrap().height, 3);

// Scrolling down 5 times
state.scroll_down();
state.scroll_down();
state.scroll_down();
state.scroll_down();
state.scroll_down();

// Render it
scroll_view.render(...);

// Are we at the bottom?
assert!(state.is_at_bottom()); // FAILS!
// This is because rendering resets our offset to cater for the page size
assert_eq!(state.offset.unwrap().y, 2);
```
See `scroll_view.rs:210-232` for why that is.

Since that felt wrong to me, I made the judgment call for `is_at_bottom()` to consider the page size. So technically it is now a `are_we_scrolled_down_enough_so_it_behaves_and_looks_like_we_are_at_the_bottom()` 🥸

I added a unit test.

Feedback? :)
