### PR TITLE
feat(tui-bar-graph): add Quadrant style

### DIFF
--- a/tui-bar-graph/README.md
+++ b/tui-bar-graph/README.md
@@ -8,6 +8,7 @@ Uses the [Colorgrad] crate for gradient coloring.
 
 ![Braille Rainbow](https://vhs.charm.sh/vhs-1sx9Ht6NzU6e28Cl51jJVv.gif)
 ![Solid Plasma](https://vhs.charm.sh/vhs-7pWuLtZpzrz1OVD04cMt1a.gif)
+![Quadrant Magma](https://vhs.charm.sh/vhs-1rx6XQ9mLiO8qybSBXRGwn.gif)
 
 <details><summary>More examples</summary>
 
@@ -26,7 +27,7 @@ Uses the [Colorgrad] crate for gradient coloring.
 ## Installation
 
 ```shell
-cargo add colorgrad ratatui tui-bar-graph
+cargo add ratatui tui-bar-graph
 ```
 
 ## Example

--- a/tui-bar-graph/examples/tui-bar-graph.rs
+++ b/tui-bar-graph/examples/tui-bar-graph.rs
@@ -99,6 +99,7 @@ fn render(frame: &mut Frame, args: &Args) {
     let width = match args.bar_style {
         BarStyle::Solid => area.width as usize,
         BarStyle::Braille => area.width as usize * 2,
+        BarStyle::Quadrant => area.width as usize * 4,
     };
     let mut data = vec![0.0; width];
     rand::rng().fill(&mut data[..]);


### PR DESCRIPTION
This style uses the block drawing 2x2 quadrant characters.
In contrast to the braille style, it renders solid rather than dots.
In contrast to the solid style, it renders two columns and rows per bar.

![Quadrant Magma](https://vhs.charm.sh/vhs-1rx6XQ9mLiO8qybSBXRGwn.gif)
