### PR TITLE
feat(tui-cards): Introduce smaller cards

### DIFF
--- a/tui-cards/README.md
+++ b/tui-cards/README.md
@@ -21,17 +21,33 @@ suite by [Joshka].
 Create a `Card` and render it directly in a frame.
 
 ```rust
-use tui_cards::{Card, Rank, Suit};
+use tui_cards::{Card, CardSize, Rank, Suit};
 
-let card = Card::new(Rank::Ace, Suit::Spades);
+let card = Card::new(Rank::Ace, Suit::Spades, CardSize::Normal);
 frame.render_widget(&card, frame.area());
 ```
+
+## Card Sizes
+
+Cards can be rendered in two sizes:
+
+| Size | Dimensions |
+|------|------------|
+| `CardSize::Normal` | 14 × 9 characters |
+| `CardSize::Small` | 8 × 5 characters |
+
+Use `CardSize::dimensions()` to get the `(width, height)` tuple for layout calculations.
 
 ## Demo
 
 ```shell
 cargo run --example card
 ```
+
+**Controls:**
+- `s` - Switch to small cards
+- `n` - Switch to normal cards
+- `q` - Quit
 
 ## More widgets
 

--- a/tui-cards/README.md
+++ b/tui-cards/README.md
@@ -38,6 +38,20 @@ Cards can be rendered in two sizes:
 
 Use `CardSize::dimensions()` to get the `(width, height)` tuple for layout calculations.
 
+## Styling
+
+Cards can be styled using the `style()` method to set foreground and background colors:
+
+```rust
+use ratatui::style::{Color, Style};
+use tui_cards::{Card, CardSize, Rank, Suit};
+
+let card = Card::new(Rank::Ace, Suit::Spades, CardSize::Normal)
+    .style(Style::new().bg(Color::White));
+```
+
+If no foreground color is specified, the card uses the suit's default color. The background defaults to transparent (`Color::Reset`).
+
 ## Demo
 
 ```shell
@@ -47,6 +61,7 @@ cargo run --example card
 **Controls:**
 - `s` - Switch to small cards
 - `n` - Switch to normal cards
+- `t` - Toggle card style (Transparent → Classic → Dark → Colorful)
 - `q` - Quit
 
 ## More widgets

--- a/tui-cards/examples/card.rs
+++ b/tui-cards/examples/card.rs
@@ -5,42 +5,45 @@ use ratatui::style::{Color, Stylize};
 use ratatui::widgets::Block;
 use ratatui::Frame;
 use strum::IntoEnumIterator;
-use tui_cards::{Card, Rank, Suit};
+use tui_cards::{Card, CardSize, Rank, Suit};
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
     let mut terminal = ratatui::init();
+    let mut card_size = CardSize::Normal;
     // fix problem with skipping the wrong number of characters when drawing cards
     // This is probably a bug in ratatui
     terminal.draw(|frame| frame.render_widget(Block::new().bg(Color::White), frame.area()))?;
     loop {
-        if terminal.draw(draw).is_err() {
+        if terminal.draw(|frame| draw(frame, card_size)).is_err() {
             break;
         }
-        if matches!(
-            event::read()?,
-            Event::Key(KeyEvent {
-                code: KeyCode::Char('q'),
-                ..
-            }),
-        ) {
-            break;
+        if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+            match code {
+                KeyCode::Char('q') => break,
+                KeyCode::Char('s') => card_size = CardSize::Small,
+                KeyCode::Char('n') => card_size = CardSize::Normal,
+                _ => {}
+            }
         }
     }
     ratatui::restore();
     Ok(())
 }
 
-fn draw(frame: &mut Frame) {
-    let width = frame.area().width / 15 * 15;
-    let height = frame.area().height / 10 * 10;
+fn draw(frame: &mut Frame, card_size: CardSize) {
+    let (card_width, card_height) = card_size.dimensions();
+    let step_x = (card_width + 1) as usize;
+    let step_y = (card_height + 1) as usize;
+    let width = frame.area().width / step_x as u16 * step_x as u16;
+    let height = frame.area().height / step_y as u16 * step_y as u16;
     let cards = Suit::iter()
         .cartesian_product(Rank::iter())
-        .map(|(suit, rank)| Card::new(rank, suit));
-    let x_iter = (0..width).step_by(15);
-    let y_iter = (0..height).step_by(10);
+        .map(|(suit, rank)| Card::new(rank, suit, card_size));
+    let x_iter = (0..width).step_by(step_x);
+    let y_iter = (0..height).step_by(step_y);
     for (card, (y, x)) in cards.zip(y_iter.cartesian_product(x_iter)) {
-        let area = Rect::new(x, y, 15, 10);
+        let area = Rect::new(x, y, card_width, card_height);
         frame.render_widget(&card, area);
     }
 }

--- a/tui-cards/examples/card.rs
+++ b/tui-cards/examples/card.rs
@@ -1,21 +1,60 @@
 use itertools::Itertools;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent};
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Stylize};
+use ratatui::style::{Color, Style, Stylize};
 use ratatui::widgets::Block;
 use ratatui::Frame;
 use strum::IntoEnumIterator;
 use tui_cards::{Card, CardSize, Rank, Suit};
 
+#[derive(Debug, Clone, Copy, Default)]
+enum CardStyle {
+    #[default]
+    Transparent,
+    Classic,
+    Dark,
+    Colorful,
+}
+
+impl CardStyle {
+    fn next(self) -> Self {
+        match self {
+            Self::Transparent => Self::Classic,
+            Self::Classic => Self::Dark,
+            Self::Dark => Self::Colorful,
+            Self::Colorful => Self::Transparent,
+        }
+    }
+
+    fn style(self) -> Style {
+        match self {
+            Self::Transparent => Style::new(),
+            Self::Classic => Style::new().bg(Color::White),
+            Self::Dark => Style::new().bg(Color::DarkGray),
+            Self::Colorful => Style::new().bg(Color::Rgb(255, 250, 205)),
+        }
+    }
+
+    fn background(self) -> Color {
+        match self {
+            Self::Transparent => Color::DarkGray,
+            Self::Classic => Color::White,
+            Self::Dark => Color::Black,
+            Self::Colorful => Color::Rgb(70, 130, 180),
+        }
+    }
+}
+
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
     let mut terminal = ratatui::init();
     let mut card_size = CardSize::Normal;
-    // fix problem with skipping the wrong number of characters when drawing cards
-    // This is probably a bug in ratatui
-    terminal.draw(|frame| frame.render_widget(Block::new().bg(Color::White), frame.area()))?;
+    let mut card_style = CardStyle::default();
     loop {
-        if terminal.draw(|frame| draw(frame, card_size)).is_err() {
+        if terminal
+            .draw(|frame| draw(frame, card_size, card_style))
+            .is_err()
+        {
             break;
         }
         if let Event::Key(KeyEvent { code, .. }) = event::read()? {
@@ -23,6 +62,7 @@ fn main() -> color_eyre::Result<()> {
                 KeyCode::Char('q') => break,
                 KeyCode::Char('s') => card_size = CardSize::Small,
                 KeyCode::Char('n') => card_size = CardSize::Normal,
+                KeyCode::Char('t') => card_style = card_style.next(),
                 _ => {}
             }
         }
@@ -31,7 +71,9 @@ fn main() -> color_eyre::Result<()> {
     Ok(())
 }
 
-fn draw(frame: &mut Frame, card_size: CardSize) {
+fn draw(frame: &mut Frame, card_size: CardSize, card_style: CardStyle) {
+    frame.render_widget(Block::new().bg(card_style.background()), frame.area());
+
     let (card_width, card_height) = card_size.dimensions();
     let step_x = (card_width + 1) as usize;
     let step_y = (card_height + 1) as usize;
@@ -39,7 +81,7 @@ fn draw(frame: &mut Frame, card_size: CardSize) {
     let height = frame.area().height / step_y as u16 * step_y as u16;
     let cards = Suit::iter()
         .cartesian_product(Rank::iter())
-        .map(|(suit, rank)| Card::new(rank, suit, card_size));
+        .map(|(suit, rank)| Card::new(rank, suit, card_size).style(card_style.style()));
     let x_iter = (0..width).step_by(step_x);
     let y_iter = (0..height).step_by(step_y);
     for (card, (y, x)) in cards.zip(y_iter.cartesian_product(x_iter)) {

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -61,7 +61,7 @@ use std::iter::zip;
 use indoc::indoc;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Stylize};
+use ratatui_core::style::{Color, Style, Stylize};
 use ratatui_core::widgets::Widget;
 use strum::{Display, EnumIter};
 
@@ -85,6 +85,7 @@ pub struct Card {
     pub rank: Rank,
     pub suit: Suit,
     pub size: CardSize,
+    pub style: Style,
 }
 
 /// The size of a card when rendered.
@@ -134,7 +135,21 @@ pub enum Suit {
 
 impl Card {
     pub const fn new(rank: Rank, suit: Suit, size: CardSize) -> Self {
-        Self { rank, suit, size }
+        Self {
+            rank,
+            suit,
+            size,
+            style: Style::new(),
+        }
+    }
+
+    /// Sets the style of the card.
+    ///
+    /// The foreground color defaults to the suit color if not specified.
+    /// The background defaults to transparent (`Color::Reset`) if not specified.
+    pub const fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
     }
 
     pub fn as_colored_symbol(&self) -> String {
@@ -218,21 +233,21 @@ impl Rank {
         match self {
             Self::Ace => indoc! {"
                 ╭──────╮
-                │Ax    │
-                │  x   │
-                │    xA│
+                │Ax  x │
+                │      │
+                │ x  xA│
                 ╰──────╯"},
             Self::Two => indoc! {"
                 ╭──────╮
-                │2x    │
+                │2x  x │
                 │      │
-                │    x2│
+                │ x  x2│
                 ╰──────╯"},
             Self::Three => indoc! {"
                 ╭──────╮
-                │3x    │
-                │  x   │
-                │    x3│
+                │3x  x │
+                │      │
+                │ x  x3│
                 ╰──────╯"},
             Self::Four => indoc! {"
                 ╭──────╮
@@ -243,38 +258,38 @@ impl Rank {
             Self::Five => indoc! {"
                 ╭──────╮
                 │5x  x │
-                │  x   │
+                │      │
                 │ x  x5│
                 ╰──────╯"},
             Self::Six => indoc! {"
                 ╭──────╮
                 │6x  x │
-                │ x  x │
+                │      │
                 │ x  x6│
                 ╰──────╯"},
             Self::Seven => indoc! {"
                 ╭──────╮
                 │7x  x │
-                │ x x x│
+                │      │
                 │ x  x7│
                 ╰──────╯"},
             Self::Eight => indoc! {"
                 ╭──────╮
-                │8x xx │
-                │ x  x │
-                │ xx x8│
+                │8x  x │
+                │      │
+                │ x  x8│
                 ╰──────╯"},
             Self::Nine => indoc! {"
                 ╭──────╮
-                │9x xx │
-                │ x x x│
-                │ xx x9│
+                │9x  x │
+                │      │
+                │ x  x9│
                 ╰──────╯"},
             Self::Ten => indoc! {"
                 ╭──────╮
-                │Tx xx │
-                │ xx x │
-                │ xx xT│
+                │10  x │
+                │      │
+                │ x  10│
                 ╰──────╯"},
             Self::Jack => indoc! {"
                 ╭──────╮
@@ -452,9 +467,10 @@ impl Widget for &Card {
                 template.replace("xx", symbol)
             }
         };
-        let color = self.suit.color();
+        let fg = self.style.fg.unwrap_or(self.suit.color());
+        let bg = self.style.bg.unwrap_or(Color::Reset);
         for (line, row) in zip(card.lines(), area.rows()) {
-            let span = line.fg(color).bg(Color::White);
+            let span = line.fg(fg).bg(bg);
             span.render(row, buf);
         }
     }

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -17,10 +17,10 @@
 //! Create a `Card` and render it directly in a frame.
 //!
 //! ```no_run
-//! use tui_cards::{Card, Rank, Suit};
+//! use tui_cards::{Card, CardSize, Rank, Suit};
 //!
 //! # fn draw(frame: &mut ratatui::Frame) {
-//! let card = Card::new(Rank::Ace, Suit::Spades);
+//! let card = Card::new(Rank::Ace, Suit::Spades, CardSize::Normal);
 //! frame.render_widget(&card, frame.area());
 //! # }
 //! ```
@@ -67,12 +67,16 @@ use strum::{Display, EnumIter};
 
 /// A playing card.
 ///
+/// Card dimensions depend on the size:
+/// - `CardSize::Normal`: 14 characters wide × 9 lines tall
+/// - `CardSize::Small`: 8 characters wide × 5 lines tall
+///
 /// # Example
 ///
 /// ```rust
-/// use tui_cards::{Card, Rank, Suit};
+/// use tui_cards::{Card, CardSize, Rank, Suit};
 /// # fn draw(frame: &mut ratatui::Frame) {
-/// let card = Card::new(Rank::Ace, Suit::Spades);
+/// let card = Card::new(Rank::Ace, Suit::Spades, CardSize::Normal);
 /// frame.render_widget(&card, frame.area());
 /// # }
 /// ```
@@ -80,6 +84,27 @@ use strum::{Display, EnumIter};
 pub struct Card {
     pub rank: Rank,
     pub suit: Suit,
+    pub size: CardSize,
+}
+
+/// The size of a card when rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CardSize {
+    /// Small card: 8 characters wide × 5 lines tall.
+    Small,
+    /// Normal card: 14 characters wide × 9 lines tall.
+    #[default]
+    Normal,
+}
+
+impl CardSize {
+    /// Returns the dimensions (width, height) of the card.
+    pub const fn dimensions(self) -> (u16, u16) {
+        match self {
+            Self::Small => (8, 5),
+            Self::Normal => (14, 9),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter)]
@@ -108,8 +133,8 @@ pub enum Suit {
 }
 
 impl Card {
-    pub const fn new(rank: Rank, suit: Suit) -> Self {
-        Self { rank, suit }
+    pub const fn new(rank: Rank, suit: Suit, size: CardSize) -> Self {
+        Self { rank, suit, size }
     }
 
     pub fn as_colored_symbol(&self) -> String {
@@ -180,7 +205,100 @@ impl Suit {
 }
 
 impl Rank {
-    pub const fn template(self) -> &'static str {
+    /// Returns the template for the given card size.
+    pub const fn template(self, size: CardSize) -> &'static str {
+        match size {
+            CardSize::Small => self.small_template(),
+            CardSize::Normal => self.normal_template(),
+        }
+    }
+
+    /// Returns the small template (8 wide × 5 tall).
+    pub const fn small_template(self) -> &'static str {
+        match self {
+            Self::Ace => indoc! {"
+                ╭──────╮
+                │Ax    │
+                │  x   │
+                │    xA│
+                ╰──────╯"},
+            Self::Two => indoc! {"
+                ╭──────╮
+                │2x    │
+                │      │
+                │    x2│
+                ╰──────╯"},
+            Self::Three => indoc! {"
+                ╭──────╮
+                │3x    │
+                │  x   │
+                │    x3│
+                ╰──────╯"},
+            Self::Four => indoc! {"
+                ╭──────╮
+                │4x  x │
+                │      │
+                │ x  x4│
+                ╰──────╯"},
+            Self::Five => indoc! {"
+                ╭──────╮
+                │5x  x │
+                │  x   │
+                │ x  x5│
+                ╰──────╯"},
+            Self::Six => indoc! {"
+                ╭──────╮
+                │6x  x │
+                │ x  x │
+                │ x  x6│
+                ╰──────╯"},
+            Self::Seven => indoc! {"
+                ╭──────╮
+                │7x  x │
+                │ x x x│
+                │ x  x7│
+                ╰──────╯"},
+            Self::Eight => indoc! {"
+                ╭──────╮
+                │8x xx │
+                │ x  x │
+                │ xx x8│
+                ╰──────╯"},
+            Self::Nine => indoc! {"
+                ╭──────╮
+                │9x xx │
+                │ x x x│
+                │ xx x9│
+                ╰──────╯"},
+            Self::Ten => indoc! {"
+                ╭──────╮
+                │Tx xx │
+                │ xx x │
+                │ xx xT│
+                ╰──────╯"},
+            Self::Jack => indoc! {"
+                ╭──────╮
+                │Jx    │
+                │  JJ  │
+                │    xJ│
+                ╰──────╯"},
+            Self::Queen => indoc! {"
+                ╭──────╮
+                │Qx    │
+                │  QQ  │
+                │    xQ│
+                ╰──────╯"},
+            Self::King => indoc! {"
+                ╭──────╮
+                │Kx    │
+                │  KK  │
+                │    xK│
+                ╰──────╯"},
+        }
+    }
+
+    /// Returns the normal template (14 wide × 9 tall).
+    pub const fn normal_template(self) -> &'static str {
         match self {
             Self::Ace => indoc! {"
                 ╭────────────╮
@@ -323,9 +441,17 @@ impl Widget for &Card {
     where
         Self: Sized,
     {
-        let template = self.rank.template();
-        let symbol = self.suit.as_four_color_symbol();
-        let card = template.replace("xx", symbol);
+        let template = self.rank.template(self.size);
+        let card = match self.size {
+            CardSize::Small => {
+                let symbol = self.suit.as_symbol();
+                template.replace('x', &symbol.to_string())
+            }
+            CardSize::Normal => {
+                let symbol = self.suit.as_four_color_symbol();
+                template.replace("xx", symbol)
+            }
+        };
         let color = self.suit.color();
         for (line, row) in zip(card.lines(), area.rows()) {
             let span = line.fg(color).bg(Color::White);


### PR DESCRIPTION
### Summary

  - Add CardSize enum with Small (8×5) and Normal (14×9) variants
  - Add dimensions() method for layout calculations
  - Update example with s/n keys to toggle card sizes

  - Run cargo `run --example card` and press `s` and `n` to switch sizes
  

