### PR TITLE
feat(tui-prompts): add disable status option

### DIFF
--- a/tui-prompts/src/text_prompt.rs
+++ b/tui-prompts/src/text_prompt.rs
@@ -22,14 +22,18 @@ use crate::prelude::*;
 // TODO handle bracketed paste.
 
 /// A prompt widget that displays a message and a text input.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+///
+/// By default, the prompt reserves space for the [`TextState`] status symbol before the prompt
+/// message. Use [`TextPrompt::without_status_symbol`] when the surrounding UI owns completion or
+/// cancellation state and the prompt should start directly with the message.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextPrompt<'a> {
     /// The message to display to the user before the input.
     message: Cow<'a, str>,
     /// The block to wrap the prompt in.
     block: Option<Block<'a>>,
     render_style: TextRenderStyle,
-    status_enabled: bool,
+    status_symbol_visible: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -58,7 +62,7 @@ impl<'a> TextPrompt<'a> {
             message,
             block: None,
             render_style: TextRenderStyle::Default,
-            status_enabled: true,
+            status_symbol_visible: true,
         }
     }
 
@@ -74,10 +78,21 @@ impl<'a> TextPrompt<'a> {
         self
     }
 
+    /// Renders the prompt without the status symbol or its following space.
+    ///
+    /// The prompt state's [`Status`] is still updated and available through [`TextState`]. This
+    /// only changes the rendered prefix, so the prompt message, input value, wrapping width, and
+    /// cursor position all move left by the width of the hidden status symbol prefix.
     #[must_use]
-    pub const fn with_status_disabled(mut self) -> Self {
-        self.status_enabled = false;
+    pub const fn without_status_symbol(mut self) -> Self {
+        self.status_symbol_visible = false;
         self
+    }
+}
+
+impl Default for TextPrompt<'_> {
+    fn default() -> Self {
+        Self::new(Cow::Borrowed(""))
     }
 }
 
@@ -107,7 +122,7 @@ impl<'a> StatefulWidget for TextPrompt<'a> {
 
         let line = {
             let mut parts = vec![];
-            if self.status_enabled {
+            if self.status_symbol_visible {
                 parts.push(state.status().symbol());
                 parts.push(" ".into());
             }
@@ -261,6 +276,19 @@ mod tests {
     }
 
     #[test]
+    fn render_default_keeps_status_symbol() {
+        let prompt = TextPrompt::default();
+        let mut state = TextState::new().with_status(Status::Done);
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
+
+        prompt.render(buffer.area, &mut buffer, &mut state);
+
+        let line = line!["✔".green(), " ", " › ".cyan().dim(), "   "];
+        assert_eq!(buffer, Buffer::with_lines([line]));
+        assert_eq!(state.cursor(), (5, 0));
+    }
+
+    #[test]
     fn render_emoji() {
         let prompt = TextPrompt::from("🔍");
         let mut state = TextState::new();
@@ -304,8 +332,8 @@ mod tests {
     }
 
     #[test]
-    fn render_with_disabled_status() {
-        let prompt = TextPrompt::from("prompt").with_status_disabled();
+    fn render_without_status_symbol() {
+        let prompt = TextPrompt::from("prompt").without_status_symbol();
         let mut state = TextState::new().with_status(Status::Aborted);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 13, 1));
 
@@ -313,6 +341,7 @@ mod tests {
 
         let line = line!["prompt".bold(), " › ".cyan().dim(), "    "];
         assert_eq!(buffer, Buffer::with_lines([line]));
+        assert_eq!(state.cursor(), (9, 0));
     }
 
     #[test]


### PR DESCRIPTION
Allow removal of the status indicator for text inputs that don't need validation.