### PR TITLE
[codex] Vendor CI workflows into this repository

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,13 +5,65 @@ on:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
-  check:
-    permissions:
-      checks: write
-    uses: joshka/github-workflows/.github/workflows/rust-check.yml@main
-    with:
-      msrv: 1.88.0
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Run format check
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Build docs
+        run: cargo doc --all-features --workspace
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.88.0
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Check workspace on MSRV
+        run: cargo check --all-features --workspace
+
   readme:
     name: Readme
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,44 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    uses: joshka/github-workflows/.github/workflows/rust-test.yml@main
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Run tests with coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Install minimal-versions tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-minimal-versions,cargo-hack
+      - name: Check minimal dependency floors
+        run: cargo minimal-versions check --direct --lib

--- a/.github/workflows/tui-scrollbar.yml
+++ b/.github/workflows/tui-scrollbar.yml
@@ -1,4 +1,4 @@
-name: tui-scrollbar (crossterm matrix)
+name: Tui-scrollbar
 
 permissions:
   contents: read
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check:
-    name: Cargo check (${{ matrix.features.name }})
+    name: Check (${{ matrix.features.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
         run: cargo check ${{ matrix.features.args }}
 
   docsrs:
-    name: Docs.rs build (nightly)
+    name: docs.rs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/tui-big-text/src/big_text.rs
+++ b/tui-big-text/src/big_text.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-
 use core::cmp::min;
 
 use derive_builder::Builder;

--- a/tui-prompts/src/lib.rs
+++ b/tui-prompts/src/lib.rs
@@ -40,8 +40,7 @@
 //!     fn draw_ui(&mut self, frame: &mut Frame) {
 //!         let (username_area, password_area, invisible_area) = split_layout(frame.area());
 //!
-//!         TextPrompt::from("Username")
-//!             .draw(frame, username_area, &mut self.username_state);
+//!         TextPrompt::from("Username").draw(frame, username_area, &mut self.username_state);
 //!
 //!         TextPrompt::from("Password")
 //!             .with_render_style(TextRenderStyle::Password)

--- a/tui-scrollbar/README.md
+++ b/tui-scrollbar/README.md
@@ -195,8 +195,8 @@ let scrollbar = ScrollBar::vertical(lengths).glyph_set(GlyphSet::unicode());
 
 ## Features
 
-- `crossterm`: enables crossterm mouse events (latest supported version, currently
-  `crossterm` 0.29).
+- `crossterm`: enables crossterm mouse events (latest supported version, currently `crossterm`
+  0.29).
 - `crossterm_0_28`: enables crossterm mouse events using `crossterm` 0.28.
 - `crossterm_0_29`: enables crossterm mouse events using `crossterm` 0.29.
 

--- a/tui-scrollbar/src/lib.rs
+++ b/tui-scrollbar/src/lib.rs
@@ -197,8 +197,8 @@
 //!
 //! # Features
 //!
-//! - `crossterm`: enables crossterm mouse events (latest supported version, currently
-//!   `crossterm` 0.29).
+//! - `crossterm`: enables crossterm mouse events (latest supported version, currently `crossterm`
+//!   0.29).
 //! - `crossterm_0_28`: enables crossterm mouse events using `crossterm` 0.28.
 //! - `crossterm_0_29`: enables crossterm mouse events using `crossterm` 0.29.
 //!
@@ -266,15 +266,11 @@ mod lengths;
 mod metrics;
 mod scrollbar;
 
-pub use crate::glyphs::GlyphSet;
-pub use crate::input::{
-    PointerButton, PointerEvent, PointerEventKind, ScrollAxis, ScrollBarInteraction, ScrollCommand,
-    ScrollEvent, ScrollWheel,
-};
-pub use crate::lengths::ScrollLengths;
-pub use crate::metrics::{CellFill, HitTest, ScrollMetrics, SUBCELL};
-pub use crate::scrollbar::{ScrollBar, ScrollBarArrows, ScrollBarOrientation, TrackClickBehavior};
-
+/// Re-export of the selected crossterm version.
+///
+/// See `tui_scrollbar::crossterm` for the version selection rules.
+#[cfg(all(feature = "crossterm_0_28", not(feature = "crossterm_0_29")))]
+pub use ::crossterm_0_28 as crossterm;
 /// Re-export of the selected crossterm version.
 ///
 /// This crate supports multiple crossterm versions via feature flags:
@@ -289,8 +285,11 @@ pub use crate::scrollbar::{ScrollBar, ScrollBarArrows, ScrollBarOrientation, Tra
 #[cfg(feature = "crossterm_0_29")]
 pub use ::crossterm_0_29 as crossterm;
 
-/// Re-export of the selected crossterm version.
-///
-/// See `tui_scrollbar::crossterm` for the version selection rules.
-#[cfg(all(feature = "crossterm_0_28", not(feature = "crossterm_0_29")))]
-pub use ::crossterm_0_28 as crossterm;
+pub use crate::glyphs::GlyphSet;
+pub use crate::input::{
+    PointerButton, PointerEvent, PointerEventKind, ScrollAxis, ScrollBarInteraction, ScrollCommand,
+    ScrollEvent, ScrollWheel,
+};
+pub use crate::lengths::ScrollLengths;
+pub use crate::metrics::{CellFill, HitTest, ScrollMetrics, SUBCELL};
+pub use crate::scrollbar::{ScrollBar, ScrollBarArrows, ScrollBarOrientation, TrackClickBehavior};

--- a/tui-scrollbar/src/scrollbar/interaction.rs
+++ b/tui-scrollbar/src/scrollbar/interaction.rs
@@ -7,11 +7,11 @@
 //! When a pointer presses inside the thumb, the handler stores a subcell grab offset so subsequent
 //! drag events keep the pointer anchored to the same position within the thumb.
 
-#[cfg(any(feature = "crossterm_0_28", feature = "crossterm_0_29"))]
-use crate::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui_core::layout::Rect;
 
 use super::{ArrowHit, ArrowLayout, ScrollBar, ScrollBarOrientation, TrackClickBehavior};
+#[cfg(any(feature = "crossterm_0_28", feature = "crossterm_0_29"))]
+use crate::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use crate::input::{
     DragState, PointerButton, PointerEvent, PointerEventKind, ScrollAxis, ScrollBarInteraction,
     ScrollCommand, ScrollEvent, ScrollWheel,

--- a/tui-scrollview/README.md
+++ b/tui-scrollview/README.md
@@ -2,7 +2,8 @@
 
 <!-- cargo-rdme start -->
 
-A [Ratatui] widget to build smooth scrollable views. Part of the [tui-widgets] suite by [Joshka].
+A [Ratatui] widget to build smooth scrollable views. Part of the [tui-widgets] suite by
+[Joshka].
 
 ![Demo](https://vhs.charm.sh/vhs-6PuT3pdwSTp4aTvKrCBx9F.gif)
 

--- a/tui-scrollview/src/lib.rs
+++ b/tui-scrollview/src/lib.rs
@@ -1,4 +1,5 @@
-//! A [Ratatui] widget to build smooth scrollable views. Part of the [tui-widgets] suite by [Joshka].
+//! A [Ratatui] widget to build smooth scrollable views. Part of the [tui-widgets] suite by
+//! [Joshka].
 //!
 //! ![Demo](https://vhs.charm.sh/vhs-6PuT3pdwSTp4aTvKrCBx9F.gif)
 //!


### PR DESCRIPTION
## Summary

Move the main CI workflows into this repository instead of reusing `joshka/github-workflows`.

This inlines the check and test jobs so the CI behavior is defined locally and follows this repo's intended toolchain split:

- `format` runs on nightly with `rustfmt` installed explicitly
- `clippy`, coverage, minimal-versions, and README checks run on stable
- docs run on nightly
- MSRV remains a dedicated Rust 1.88.0 check

The minimal-versions job installs `cargo-minimal-versions` and `cargo-hack` via `taiki-e/install-action` and runs `cargo minimal-versions check --direct --lib`.

The README job no longer uses the Rust cache. It installs `cargo-rdme` with `cargo-binstall` and checks the generated README content directly.

Regenerated READMEs were also committed where the new in-repo check correctly detected drift:

- `tui-scrollbar/README.md`
- `tui-scrollview/README.md`

## Validation

- Parsed workflow YAML locally with Ruby `YAML.load_file`
- Ran `cargo +nightly fmt --all -- --check` locally
- Ran `cargo-rdme --check` locally and regenerated the out-of-date READMEs

## Notes

This remains a draft until the updated GitHub Actions runs complete on the PR.
