### PR TITLE
[codex] fix(ci): avoid direct secret check in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -26,7 +28,7 @@ jobs:
       - name: Run tests with coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info


### PR DESCRIPTION
## Summary

Stop referencing the `secrets` context directly in the Codecov upload step condition.

Expose `CODECOV_TOKEN` as a job env var and gate the upload step on `env.CODECOV_TOKEN` instead.

## Why

GitHub Actions rejects `if: ${{ secrets.CODECOV_TOKEN !=  }}` in this workflow context, which makes `.github/workflows/test.yml` invalid.

## Validation

- Parsed `.github/workflows/test.yml` with Ruby YAML
