### PR TITLE
chore(deps): support strum 0.28

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
+  targets:
+    name: Check Targets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Check all workspace targets
+        run: cargo check --all-targets --all-features --workspace
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf 0.11.3",
+ "phf",
 ]
 
 [[package]]
@@ -405,8 +405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02ee6eae4d99456f92dc379ba21cf08f783ef5525f193c3854b4e921ece045c5"
 dependencies = [
  "num-traits",
- "phf 0.13.1",
- "serde",
 ]
 
 [[package]]
@@ -679,12 +677,6 @@ dependencies = [
  "bit-set",
  "regex",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filedescriptor"
@@ -1317,19 +1309,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
+ "phf_macros",
+ "phf_shared",
 ]
 
 [[package]]
@@ -1338,8 +1319,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -1348,18 +1329,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -1368,25 +1339,11 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "uncased",
 ]
 
 [[package]]
@@ -1396,16 +1353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -1569,7 +1516,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1621,7 +1568,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1905,7 +1852,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -1913,6 +1869,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1950,7 +1918,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf 0.11.3",
+ "phf",
  "phf_codegen",
 ]
 
@@ -1987,7 +1955,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf 0.11.3",
+ "phf",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -2182,10 +2150,11 @@ dependencies = [
  "color-eyre",
  "colorgrad",
  "crossterm 0.29.0",
+ "document-features",
  "rand 0.10.0",
  "ratatui",
  "ratatui-core",
- "strum",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -2202,7 +2171,7 @@ dependencies = [
  "ratatui",
  "ratatui-core",
  "ratatui-widgets",
- "strum",
+ "strum 0.28.0",
  "tokio",
 ]
 
@@ -2225,7 +2194,7 @@ dependencies = [
  "itertools",
  "ratatui",
  "ratatui-core",
- "strum",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -2325,15 +2294,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ratatui-core = { version = "0.1" }
 ratatui-macros = "0.7"
 ratatui-widgets = { version = "0.3" }
 rstest = "0.26"
-strum = { version = "0.27", default-features = false, features = ["derive"] }
+strum = { version = "0.28", default-features = false, features = ["derive"] }
 tokio = { version = "1" }
 
 [lints.rust]

--- a/tui-bar-graph/Cargo.toml
+++ b/tui-bar-graph/Cargo.toml
@@ -11,8 +11,18 @@ rust-version.workspace = true
 categories.workspace = true
 keywords.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["std"]
+## enables std
+std = ["strum/std"]
+
 [dependencies]
-colorgrad = { version = "0.8", features = ["preset"] }
+colorgrad = { version = "0.8", default-features = false, features = ["preset"] }
+document-features.workspace = true
 ratatui-core.workspace = true
 strum.workspace = true
 
@@ -22,3 +32,7 @@ color-eyre.workspace = true
 crossterm.workspace = true
 rand.workspace = true
 ratatui = { workspace = true, default-features = true }
+
+[[example]]
+name = "tui-bar-graph"
+required-features = ["std"]

--- a/tui-bar-graph/src/lib.rs
+++ b/tui-bar-graph/src/lib.rs
@@ -81,6 +81,8 @@
 //!
 //! [Joshka]: https://github.com/joshka
 //! [tui-widgets]: https://crates.io/crates/tui-widgets
+#![cfg_attr(docsrs, doc = "\n# Feature flags\n")]
+#![cfg_attr(docsrs, doc = document_features::document_features!())]
 
 use colorgrad::Gradient;
 use ratatui_core::buffer::Buffer;


### PR DESCRIPTION
## Summary

This PR fixes the `strum 0.28` dependency bump proposed in [#210](https://github.com/ratatui/tui-widgets/pull/210) and adds explicit `cargo check --all-targets --all-features --workspace` coverage so example-target compile failures are caught directly in CI instead of being missed by the existing workspace check.

## Root Cause

The failure came from the `tui-bar-graph` example, where clap derives a parser for `BarStyle`.

`BarStyle` still derives `FromStr`, and this was not caused by the `#[strum(default)]` behavior change from [strum PR #476](https://github.com/Peternator7/strum/pull/476). The actual issue was dependency resolution plus feature unification.

Before the bump, `tui-bar-graph` and `ratatui-core` both used `strum 0.27`, so Cargo unified them and `ratatui-core`'s `strum/std` activation effectively carried `std` into the `strum` instance used by `tui-bar-graph`. After [#210](https://github.com/ratatui/tui-widgets/pull/210), `tui-bar-graph` used `strum 0.28` while `ratatui-core` still used `strum 0.27`, so the graph split into separate `strum` packages.

At that point, `tui-bar-graph`'s own `strum 0.28` was built with `default-features = false`, which meant `strum::ParseError` no longer implemented `std::error::Error` in that context. That was enough to break clap's inferred parser for `BarStyle`.

## Code Changes

`tui-bar-graph` now declares an explicit `std` feature and uses it to enable `strum/std`. `std` remains enabled by default, so the crate's normal ergonomics do not change.

The interactive example is marked with `required-features = ["std"]` so its compile requirements are explicit instead of depending on accidental transitive feature behavior.

`colorgrad` now uses `default-features = false`.

## Why Only `strum/std`

`strum/std` matters here because it affects trait-based downstream integration on a public enum type. `BarStyle` derives traits whose interaction with clap depends on the trait set of `strum::ParseError`.

`colorgrad/std` does not play the same role in this crate today, so the `std` feature does not forward `colorgrad/std`.

## Docs

The crate now uses `document-features` so the feature contract is rendered in generated docs and on docs.rs.

## CI

The issue exposed by [#210](https://github.com/ratatui/tui-widgets/pull/210) was a normal compile failure in a non-lib target.

The workspace already ran `cargo check --all-features --workspace`, but that does not compile examples and other non-lib targets. `cargo check --all-targets --all-features --workspace` reproduces the failure directly.

This PR adds explicit all-targets compile coverage so example-target breakage is caught as a normal build/check failure.

## Verification

```shell
cargo check --all-targets --all-features --workspace
cargo clippy --all-targets --all-features --workspace -- -D warnings
cargo check -p tui-bar-graph --lib --no-default-features
cargo doc -p tui-bar-graph --all-features
cargo rdme --check --manifest-path tui-bar-graph/Cargo.toml
```

## Follow-up

A broader `no_std` audit of the other widget crates was done during this work and recorded separately on [#102](https://github.com/ratatui/tui-widgets/issues/102).
