### PR TITLE
fix: restore stable clippy baseline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,17 +26,29 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
+    name: Clippy (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Beta Clippy runs as an early-warning gate for new lints before they reach stable. This
+        # keeps future stable releases from turning unrelated PRs red because the baseline already
+        # broke on main.
+        toolchain:
+          - stable
+          - beta
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+        run: cargo +${{ matrix.toolchain }} clippy --all-targets --all-features --workspace -- -D warnings
 
   targets:
     name: Check Targets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,17 @@
 
 ## Build, Test, and Development Commands
 
+- List project helper commands: `just --list`.
 - Format: `cargo fmt --all` (check only: `cargo fmt --all -- --check`).
 - Lint: `cargo clippy --all-targets --all-features --workspace` (pedantic/nursery enabled; fix or
   justify warnings).
+- Stable Clippy gate: `just clippy-stable` (runs `cargo +stable clippy --all-targets
+  --all-features --workspace -- -D warnings`).
+- Beta Clippy early-warning gate: `just clippy-beta` (same command on `+beta` to catch lints before
+  they reach stable). This repo treats Clippy warnings as a PR-status signal, so beta helps find
+  upcoming lint failures while they are still maintenance work instead of inherited breakage on
+  unrelated PRs.
+- Run both Clippy gates: `just clippy-all`.
 - Test full workspace: `cargo test --all-features --workspace`.
 - Test a single crate: `cargo test -p tui-prompts --all-features -- --nocapture`.
 - Docs smoke test: `cargo doc --all-features --workspace`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,27 @@
+set shell := ["bash", "-uc"]
+
+default:
+    @just --list
+
+fmt:
+    cargo fmt --all
+
+fmt-check:
+    cargo fmt --all -- --check
+
+clippy toolchain="stable":
+    cargo +{{toolchain}} clippy --all-targets --all-features --workspace -- -D warnings
+
+clippy-stable:
+    just clippy stable
+
+clippy-beta:
+    just clippy beta
+
+clippy-all: clippy-stable clippy-beta
+
+test:
+    cargo test --all-features --workspace
+
+test-scrollbar:
+    cargo test -p tui-scrollbar --all-features

--- a/tui-scrollbar/src/metrics.rs
+++ b/tui-scrollbar/src/metrics.rs
@@ -118,16 +118,14 @@ impl ScrollMetrics {
         let max_offset = content_len.saturating_sub(viewport_len);
         let offset = offset.min(max_offset);
 
-        let (thumb_len, thumb_start) = if max_offset == 0 {
-            (track_len, 0)
-        } else {
-            let thumb_len = (track_len.saturating_mul(viewport_len) / content_len)
-                .max(SUBCELL)
-                .min(track_len);
-            let thumb_travel = track_len.saturating_sub(thumb_len);
-            let thumb_start = thumb_travel.saturating_mul(offset) / max_offset;
-            (thumb_len, thumb_start)
-        };
+        let thumb_len = (track_len.saturating_mul(viewport_len) / content_len)
+            .max(SUBCELL)
+            .min(track_len);
+        let thumb_travel = track_len.saturating_sub(thumb_len);
+        let thumb_start = thumb_travel
+            .saturating_mul(offset)
+            .checked_div(max_offset)
+            .unwrap_or(0);
 
         Self {
             content_len,
@@ -206,11 +204,11 @@ impl ScrollMetrics {
     /// Larger offsets move the thumb toward the end of the track, clamped to the maximum travel.
     pub fn thumb_start_for_offset(&self, offset: usize) -> usize {
         let max_offset = self.max_offset();
-        if max_offset == 0 {
-            return 0;
-        }
         let offset = offset.min(max_offset);
-        self.thumb_travel().saturating_mul(offset) / max_offset
+        self.thumb_travel()
+            .saturating_mul(offset)
+            .checked_div(max_offset)
+            .unwrap_or(0)
     }
 
     /// Converts a thumb start position (in subcells) to an offset (in subcells).
@@ -218,11 +216,11 @@ impl ScrollMetrics {
     /// Thumb positions beyond the end of travel are clamped to the maximum offset.
     pub fn offset_for_thumb_start(&self, thumb_start: usize) -> usize {
         let max_offset = self.max_offset();
-        if max_offset == 0 {
-            return 0;
-        }
         let thumb_start = thumb_start.min(self.thumb_travel());
-        max_offset.saturating_mul(thumb_start) / self.thumb_travel()
+        max_offset
+            .saturating_mul(thumb_start)
+            .checked_div(self.thumb_travel())
+            .unwrap_or(0)
     }
 
     /// Returns how much of a cell is filled by the thumb.
@@ -392,6 +390,18 @@ mod tests {
             viewport_len: 10,
         };
         let metrics = ScrollMetrics::new(lengths, 0, 4);
+        assert_eq!(metrics.offset_for_thumb_start(5), 0);
+    }
+
+    #[test]
+    fn conversions_return_zero_when_thumb_cannot_travel() {
+        let lengths = crate::ScrollLengths {
+            content_len: 10,
+            viewport_len: 3,
+        };
+        let metrics = ScrollMetrics::new(lengths, 0, 1);
+        assert_eq!(metrics.thumb_travel(), 0);
+        assert_eq!(metrics.thumb_start_for_offset(5), 0);
         assert_eq!(metrics.offset_for_thumb_start(5), 0);
     }
 


### PR DESCRIPTION
Summary:
- Replace the guarded scrollbar division pattern with checked division so stable Clippy passes with `-D warnings`.
- Add `just` recipes for stable and beta Clippy, formatting, and targeted scrollbar tests.
- Run Clippy on both stable and beta in GitHub Actions, with the beta rationale documented in the workflow and AGENTS.md.

Validation:
- `just clippy-all`
- `just test-scrollbar`
- `cargo fmt --all -- --check` (passes with existing stable-rustfmt warnings about nightly-only rustfmt options)
- `markdownlint-cli2 AGENTS.md .plans/0002-fix-stable-clippy-baseline.md`
- `.github/workflows/check.yml` parses as YAML