### PR TITLE
ci: add auto-merge required gate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,3 +120,27 @@ jobs:
           cargo rdme --check --manifest-path tui-qrcode/Cargo.toml
           cargo rdme --check --manifest-path tui-scrollbar/Cargo.toml
           cargo rdme --check --manifest-path tui-scrollview/Cargo.toml
+
+  required:
+    runs-on: ubuntu-latest
+    needs:
+      - format
+      - clippy
+      - targets
+      - docs
+      - msrv
+      - readme
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          HAS_FAILED_JOB: >-
+            ${{
+              contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+              || contains(needs.*.result, 'skipped')
+            }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$HAS_FAILED_JOB" = "false"


### PR DESCRIPTION
## Summary
- add a single aggregate required CI job for repository rulesets
- fail the aggregate job when any required dependency fails, is cancelled, or is skipped

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/check.yml"); puts "ok"'
