### PR TITLE
ci: quiet Dependabot MSRV updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,24 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Delay fresh releases so supply-chain attacks have time to be discovered.
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      # MSRV toolchain bumps are intentional maintainer work.
+      - dependency-name: "dtolnay/rust-toolchain"
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     versioning-strategy: "increase-if-necessary"
+    # Delay fresh releases so supply-chain attacks have time to be discovered.
+    cooldown:
+      default-days: 7
     groups:
       cargo-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

- Add 7-day Dependabot cooldowns for GitHub Actions and Cargo updates.
- Ignore `dtolnay/rust-toolchain` so the fixed MSRV pin is not bumped automatically.
- Document that cooldowns give fresh releases time for supply-chain attacks to be discovered, and that MSRV bumps are intentional maintainer work.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML parsed"'`

Prevents repeats of #226.