### PR TITLE
ci: add cargo-deny policy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,6 +72,29 @@ jobs:
       - name: Check all workspace targets
         run: cargo check --all-targets --all-features --workspace
 
+  cargo-deny:
+    name: cargo-deny (${{ matrix.checks }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent a newly announced advisory from suddenly failing unrelated pull requests.
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+        with:
+          rust-version: stable
+          log-level: info
+          arguments: --all-features
+          command: check ${{ matrix.checks }}
+
   docs:
     name: Docs
     runs-on: ubuntu-latest
@@ -174,6 +197,7 @@ jobs:
       - format
       - clippy
       - targets
+      - cargo-deny
       - docs
       - msrv
       - readme

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,22 @@
+# Configuration for <https://github.com/EmbarkStudios/cargo-deny>.
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
+
+[advisories]
+version = 2
+
+[bans]
+multiple-versions = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

- add a minimal cargo-deny policy for advisories, licenses, bans, and sources
- run cargo-deny in CI with advisory checks separated from blocking policy checks
- keep RustSec advisories visible without suddenly failing unrelated PRs

## Validation

- cargo deny --all-features check advisories
- cargo deny --all-features check bans licenses sources
- markdownlint-cli2 .plans/0006-add-cargo-audit.md .plans/0007-add-cargo-deny.md
- docker run --rm -v "/Users/joshka/local/tui-widgets:/repo" -w /repo rhysd/actionlint:1.7.12 -color
- zizmor .github/workflows/check.yml