### PR TITLE
ci: add cargo-semver-checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,6 +95,28 @@ jobs:
           arguments: --all-features
           command: check ${{ matrix.checks }}
 
+  semver-checks:
+    name: Semver Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2
+        with:
+          tool: cargo-semver-checks@0.48
+      - name: Run cargo-semver-checks
+        run: cargo semver-checks --workspace
+
   docs:
     name: Docs
     runs-on: ubuntu-latest
@@ -198,6 +220,7 @@ jobs:
       - clippy
       - targets
       - cargo-deny
+      - semver-checks
       - docs
       - msrv
       - readme

--- a/justfile
+++ b/justfile
@@ -23,5 +23,8 @@ clippy-all: clippy-stable clippy-beta
 test:
     cargo test --all-features --workspace
 
+semver-checks:
+    cargo semver-checks --workspace
+
 test-scrollbar:
     cargo test -p tui-scrollbar --all-features


### PR DESCRIPTION
## Summary

- add a required CI job that runs `cargo semver-checks --workspace`
- add a matching `just semver-checks` recipe for local validation
- cover all publishable workspace crates without skips

## Validation

- `just semver-checks`
- `actionlint .github/workflows/check.yml`
- `markdownlint-cli2 .plans/0008-add-cargo-semver-checks.md`