### PR TITLE
ci: check remaining crate READMEs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -180,8 +180,10 @@ jobs:
           cargo rdme --check --manifest-path Cargo.toml
           cargo rdme --check --manifest-path tui-bar-graph/Cargo.toml
           cargo rdme --check --manifest-path tui-big-text/Cargo.toml
+          cargo rdme --check --manifest-path tui-box-text/Cargo.toml
           cargo rdme --check --manifest-path tui-cards/Cargo.toml
           cargo rdme --check --manifest-path tui-popup/Cargo.toml
+          cargo rdme --check --manifest-path tui-prompts/Cargo.toml
           cargo rdme --check --manifest-path tui-qrcode/Cargo.toml
           cargo rdme --check --manifest-path tui-scrollbar/Cargo.toml
           cargo rdme --check --manifest-path tui-scrollview/Cargo.toml

--- a/tui-prompts/README.md
+++ b/tui-prompts/README.md
@@ -44,8 +44,7 @@ impl<'a> App<'a> {
     fn draw_ui(&mut self, frame: &mut Frame) {
         let (username_area, password_area, invisible_area) = split_layout(frame.area());
 
-        TextPrompt::from("Username")
-            .draw(frame, username_area, &mut self.username_state);
+        TextPrompt::from("Username").draw(frame, username_area, &mut self.username_state);
 
         TextPrompt::from("Password")
             .with_render_style(TextRenderStyle::Password)


### PR DESCRIPTION
## Summary

- add the omitted tui-box-text and tui-prompts manifests to the cargo-rdme CI check
- refresh the generated tui-prompts README block so the new check passes

## Validation

- cargo rdme --check --manifest-path Cargo.toml
- cargo rdme --check --manifest-path tui-bar-graph/Cargo.toml
- cargo rdme --check --manifest-path tui-big-text/Cargo.toml
- cargo rdme --check --manifest-path tui-box-text/Cargo.toml
- cargo rdme --check --manifest-path tui-cards/Cargo.toml
- cargo rdme --check --manifest-path tui-popup/Cargo.toml
- cargo rdme --check --manifest-path tui-prompts/Cargo.toml
- cargo rdme --check --manifest-path tui-qrcode/Cargo.toml
- cargo rdme --check --manifest-path tui-scrollbar/Cargo.toml
- cargo rdme --check --manifest-path tui-scrollview/Cargo.toml