### PR TITLE
ci: add documentation hygiene checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,40 @@ jobs:
       - name: Run format check
         run: cargo fmt --all -- --check
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2
+        with:
+          tool: cargo-binstall
+      - name: Install typos
+        run: cargo binstall --no-confirm typos-cli@1.47.2
+      - name: Check spelling
+        run: typos
+
+  markdownlint:
+    name: Markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Install markdownlint-cli2
+        run: npm install --global markdownlint-cli2@0.22.1
+      - name: Lint Markdown
+        run: markdownlint-cli2 "**/*.md"
+
   clippy:
     name: Clippy (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
@@ -219,6 +253,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - format
+      - typos
+      - markdownlint
       - clippy
       - targets
       - cargo-deny

--- a/tui-big-text/README.md
+++ b/tui-big-text/README.md
@@ -82,7 +82,6 @@ BigText::builder().right_aligned();
 
 For the full suite of widgets, see [tui-widgets].
 
-[tui-big-text]: https://crates.io/crates/tui-big-text
 [Ratatui]: https://crates.io/crates/ratatui
 [font8x8]: https://crates.io/crates/font8x8
 

--- a/tui-big-text/src/lib.rs
+++ b/tui-big-text/src/lib.rs
@@ -80,7 +80,6 @@
 //!
 //! For the full suite of widgets, see [tui-widgets].
 //!
-//! [tui-big-text]: https://crates.io/crates/tui-big-text
 //! [Ratatui]: https://crates.io/crates/ratatui
 //! [font8x8]: https://crates.io/crates/font8x8
 //!

--- a/tui-popup/README.md
+++ b/tui-popup/README.md
@@ -139,7 +139,6 @@ fn render_scrollable_popup(frame: &mut Frame, scroll: u16) {
 
 For the full suite of widgets, see [tui-widgets].
 
-
 [Crate]: https://crates.io/crates/tui-popup
 [Docs]: https://docs.rs/tui-popup/
 [Dependency Status]: https://deps.rs/repo/github/ratatui/tui-widgets
@@ -159,8 +158,8 @@ For the full suite of widgets, see [tui-widgets].
 [Examples]: https://github.com/ratatui/tui-widgets/tree/main/tui-popup/examples
 [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-popup/CHANGELOG.md
 [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
-[KnownSize]: https://docs.rs/tui-popup/latest/tui_popup/trait.KnownSize.html
-[KnownSizeWrapper]: https://docs.rs/tui-popup/latest/tui_popup/struct.KnownSizeWrapper.html
+[`KnownSize`]: https://docs.rs/tui-popup/latest/tui_popup/trait.KnownSize.html
+[`KnownSizeWrapper`]: https://docs.rs/tui-popup/latest/tui_popup/struct.KnownSizeWrapper.html
 [tui-scrollview]: https://crates.io/crates/tui-scrollview
 
 [Joshka]: https://github.com/joshka

--- a/tui-popup/src/lib.rs
+++ b/tui-popup/src/lib.rs
@@ -141,7 +141,6 @@
 //!
 //! For the full suite of widgets, see [tui-widgets].
 //!
-//!
 //! [Crate]: https://crates.io/crates/tui-popup
 //! [Docs]: https://docs.rs/tui-popup/
 //! [Dependency Status]: https://deps.rs/repo/github/ratatui/tui-widgets
@@ -161,8 +160,8 @@
 //! [Examples]: https://github.com/ratatui/tui-widgets/tree/main/tui-popup/examples
 //! [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-popup/CHANGELOG.md
 //! [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
-//! [KnownSize]: https://docs.rs/tui-popup/latest/tui_popup/trait.KnownSize.html
-//! [KnownSizeWrapper]: https://docs.rs/tui-popup/latest/tui_popup/struct.KnownSizeWrapper.html
+//! [`KnownSize`]: https://docs.rs/tui-popup/latest/tui_popup/trait.KnownSize.html
+//! [`KnownSizeWrapper`]: https://docs.rs/tui-popup/latest/tui_popup/struct.KnownSizeWrapper.html
 //! [tui-scrollview]: https://crates.io/crates/tui-scrollview
 //!
 //! [Joshka]: https://github.com/joshka

--- a/tui-prompts/src/prompt.rs
+++ b/tui-prompts/src/prompt.rs
@@ -188,7 +188,7 @@ pub trait State {
             // We cannot use String::insert() as it operates on bytes, which can lead to incorrect
             // modifications with multibyte characters. Instead, we handle text
             // manipulation at the character level using Rust's char type for Unicode
-            // correctness. Check docs of String::insert() and String::chars() for futher info.
+            // correctness. Check docs of String::insert() and String::chars() for further info.
             *self.value_mut() = chain![
                 self.value().chars().take(self.position()),
                 once(c),

--- a/tui-qrcode/src/lib.rs
+++ b/tui-qrcode/src/lib.rs
@@ -590,7 +590,7 @@ mod tests {
         );
     }
 
-    /// The QR code is doubled vertically and horizontall as the min scaling means this needs to
+    /// The QR code is doubled vertically and horizontally as the min scaling means this needs to
     /// render at least 21x10.5 but the buffer is 22x12
     #[rstest]
     fn render_min_into_larger_area(empty_widget: QrCodeWidget) {
@@ -619,7 +619,7 @@ mod tests {
 
     /// The QR code is truncated as the area is smaller than the QR code
     #[rstest]
-    fn render_exact_into_smaler_area(empty_widget: QrCodeWidget) {
+    fn render_exact_into_smaller_area(empty_widget: QrCodeWidget) {
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 10));
         empty_widget.render(buf.area, &mut buf);
         assert_eq!(

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -55,7 +55,7 @@ pub struct ScrollView {
     horizontal_scrollbar_visibility: ScrollbarVisibility,
 }
 
-/// The visbility of the vertical and horizontal scrollbars.
+/// The visibility of the vertical and horizontal scrollbars.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ScrollbarVisibility {
     /// Render the scrollbar only whenever needed.
@@ -299,7 +299,7 @@ impl ScrollView {
             self.horizontal_scrollbar_visibility,
             self.vertical_scrollbar_visibility,
         ) {
-            // straightfoward, no need to check fit values
+            // straightforward, no need to check fit values
             (V::Always, V::Always) => (true, true),
             (V::Never, V::Never) => (false, false),
             (V::Always, V::Never) => (true, false),
@@ -521,7 +521,7 @@ mod tests {
         )
     }
 
-    /// Tests the scenario where the vertical scollbar steals a column from the right side of the
+    /// Tests the scenario where the vertical scrollbar steals a column from the right side of the
     /// buffer which causes the horizontal scrollbar to be shown.
     #[rstest]
     fn does_not_hide_horizontal_scrollbar(scroll_view: ScrollView) {
@@ -544,7 +544,7 @@ mod tests {
         )
     }
 
-    /// Tests the scenario where the horizontal scollbar steals a row from the bottom side of the
+    /// Tests the scenario where the horizontal scrollbar steals a row from the bottom side of the
     /// buffer which causes the vertical scrollbar to be shown.
     #[rstest]
     fn does_not_hide_vertical_scrollbar(scroll_view: ScrollView) {

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,7 @@
+[files]
+extend-exclude = [
+  "**/CHANGELOG.md",
+]
+
 [default.extend-words]
 ratatui = "ratatui"


### PR DESCRIPTION
## Summary

- add required CI jobs for typos and markdownlint-cli2
- exclude generated changelogs from spelling checks
- fix small spelling and Markdown hygiene issues caught by the new checks

## Validation

- typos
- markdownlint-cli2 "**/*.md"
- cargo rdme --check --manifest-path tui-big-text/Cargo.toml
- cargo rdme --check --manifest-path tui-popup/Cargo.toml
- cargo fmt --all -- --check
- actionlint -color=false .github/workflows/check.yml