### PR TITLE
ci: report zizmor findings via code scanning

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -225,6 +225,9 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -233,7 +236,6 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
-          advanced-security: false
           inputs: .github/workflows
 
   actionlint:
@@ -262,7 +264,6 @@ jobs:
       - docs
       - msrv
       - readme
-      - zizmor
       - actionlint
     if: ${{ always() }}
     steps:


### PR DESCRIPTION
## Summary

- move zizmor to the default Advanced Security/SARIF integration
- grant the zizmor job `security-events: write` for code scanning upload while keeping `contents: read` for checkout
- remove zizmor from the synthetic `required` CI gate so findings are reported in the Security tab instead of failing ordinary CI checks

## Context

The current `advanced-security: false` setup makes zizmor behave like a normal CI lint: findings fail the `zizmor` job, and the synthetic `required` job then blocks the PR. The upstream zizmor-action documentation recommends the Advanced Security mode for stateful triage, where findings are uploaded as code scanning alerts and merge blocking is handled by GitHub code scanning rulesets if desired.

This keeps the workflow job present, but moves the finding lifecycle to GitHub code scanning rather than making every finding an immediate CI failure.

## Validation

- `actionlint`
- `zizmor .github/workflows`