### PR TITLE
docs: use nightly rustfmt for formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@
 ## Build, Test, and Development Commands
 
 - List project helper commands: `just --list`.
-- Format: `cargo fmt --all` (check only: `cargo fmt --all -- --check`).
+- Format: `just fmt` (check only: `just fmt-check`). These run `cargo +nightly fmt` because
+  `rustfmt.toml` uses unstable formatting options such as comment wrapping and grouped imports.
 - Lint: `cargo clippy --all-targets --all-features --workspace` (pedantic/nursery enabled; fix or
   justify warnings).
 - Stable Clippy gate: `just clippy-stable` (runs `cargo +stable clippy --all-targets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,14 +74,16 @@ cargo test
   cargo test --all-features --workspace
   ```
 
-- Check to see if there are code formatting issues
+- Check to see if there are code formatting issues. This uses nightly rustfmt because
+  `rustfmt.toml` enables unstable options for comment wrapping and import grouping.
 
   ```shell
-  cargo fmt --all -- --check
+  just fmt-check
   ```
 
-- Format the code in the project
+- Format the code in the project. Use the same nightly-backed recipe so local formatting matches
+  check mode.
 
   ```shell
-  cargo fmt --all
+  just fmt
   ```

--- a/justfile
+++ b/justfile
@@ -4,10 +4,12 @@ default:
     @just --list
 
 fmt:
-    cargo fmt --all
+    # rustfmt.toml uses unstable rustfmt options for comment wrapping and import grouping.
+    cargo +nightly fmt --all
 
 fmt-check:
-    cargo fmt --all -- --check
+    # Keep check mode on the same toolchain as fmt so CI and local formatting agree.
+    cargo +nightly fmt --all -- --check
 
 clippy toolchain="stable":
     cargo +{{toolchain}} clippy --all-targets --all-features --workspace -- -D warnings


### PR DESCRIPTION
## Summary

- update `just fmt` and `just fmt-check` to run `cargo +nightly fmt`
- point AGENTS.md and CONTRIBUTING.md at the just recipes
- document next to the formatting commands that nightly is required because `rustfmt.toml` uses unstable rustfmt options for comment wrapping and import grouping

## Validation

- `just fmt-check`
- `markdownlint-cli2 AGENTS.md CONTRIBUTING.md`
- `just --list`
