### PR TITLE
Add tui-equalizer to workspace

### DIFF
--- a/.github/release-plz/tui-equalizer.toml
+++ b/.github/release-plz/tui-equalizer.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_config = "cliff.toml"
+pr_branch_prefix = "release-plz-tui-equalizer-"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -216,6 +216,7 @@ jobs:
           cargo rdme --check --manifest-path tui-big-text/Cargo.toml
           cargo rdme --check --manifest-path tui-box-text/Cargo.toml
           cargo rdme --check --manifest-path tui-cards/Cargo.toml
+          cargo rdme --check --manifest-path tui-equalizer/Cargo.toml
           cargo rdme --check --manifest-path tui-popup/Cargo.toml
           cargo rdme --check --manifest-path tui-prompts/Cargo.toml
           cargo rdme --check --manifest-path tui-qrcode/Cargo.toml

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,6 +44,7 @@ jobs:
           - tui-big-text
           - tui-box-text
           - tui-cards
+          - tui-equalizer
           - tui-popup
           - tui-prompts
           - tui-qrcode

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -18,3 +18,4 @@ config:
     stern: false
 ignores:
   - "**/CHANGELOG.md"
+  - "target/**"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,6 +2263,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-equalizer"
+version = "0.2.0"
+dependencies = [
+ "color-eyre",
+ "crossterm 0.29.0",
+ "itertools",
+ "rand 0.10.1",
+ "ratatui",
+ "ratatui-core",
+]
+
+[[package]]
 name = "tui-popup"
 version = "0.7.5"
 dependencies = [
@@ -2341,6 +2353,7 @@ dependencies = [
  "tui-big-text",
  "tui-box-text",
  "tui-cards",
+ "tui-equalizer",
  "tui-popup",
  "tui-prompts",
  "tui-qrcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ default = [
     "big-text",
     "box-text",
     "cards",
+    "equalizer",
     "popup",
     "prompts",
     "qrcode",
@@ -79,6 +80,8 @@ big-text = ["tui-big-text"]
 box-text = ["tui-box-text"]
 ## Enables the [`cards`] widget
 cards = ["tui-cards"]
+## Enables the [`equalizer`] widget
+equalizer = ["tui-equalizer"]
 ## Enables the [`popup`] widget
 popup = ["tui-popup"]
 ## Enables the [`prompts`] widget
@@ -97,6 +100,7 @@ tui-bar-graph = { version = "0.3.3", path = "tui-bar-graph", optional = true }
 tui-big-text = { version = "0.8.5", path = "tui-big-text", optional = true }
 tui-box-text = { version = "0.3.3", path = "tui-box-text", optional = true }
 tui-cards = { version = "0.3.3", path = "tui-cards", optional = true }
+tui-equalizer = { version = "0.2.0", path = "tui-equalizer", optional = true }
 tui-popup = { version = "0.7.5", path = "tui-popup", optional = true }
 tui-prompts = { version = "0.6.4", path = "tui-prompts", optional = true }
 tui-qrcode = { version = "0.2.5", path = "tui-qrcode", optional = true }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Workspace crates:
 - [tui-big-text]
 - [tui-box-text]
 - [tui-cards]
+- [tui-equalizer]
 - [tui-popup]
 - [tui-prompts]
 - [tui-qrcode]
@@ -42,6 +43,10 @@ The widget crates are also available as standalone crates.
 
 [![Demo](https://vhs.charm.sh/vhs-34mhPM1Juk2XnnLTGpOtE9.gif)][tui-cards]
 
+### [tui-equalizer]
+
+[![Demo](https://vhs.charm.sh/vhs-FiRQkkDAUEnH2BrPbUx5i.gif)][tui-equalizer]
+
 ### [tui-popup]
 
 [![Demo](https://vhs.charm.sh/vhs-q5Kz0QP3zmrBlQ6dofjMh.gif)][tui-popup]
@@ -63,6 +68,7 @@ The widget crates are also available as standalone crates.
 [tui-big-text]: https://crates.io/crates/tui-big-text
 [tui-box-text]: https://crates.io/crates/tui-box-text
 [tui-cards]: https://crates.io/crates/tui-cards
+[tui-equalizer]: https://crates.io/crates/tui-equalizer
 [tui-popup]: https://crates.io/crates/tui-popup
 [tui-prompts]: https://crates.io/crates/tui-prompts
 [tui-qrcode]: https://crates.io/crates/tui-qrcode

--- a/justfile
+++ b/justfile
@@ -11,6 +11,9 @@ fmt-check:
     # Keep check mode on the same toolchain as fmt so CI and local formatting agree.
     cargo +nightly fmt --all -- --check
 
+rdme-check:
+    for manifest in Cargo.toml tui-*/Cargo.toml; do cargo rdme --check --manifest-path "$manifest"; done
+
 clippy toolchain="stable":
     cargo +{{toolchain}} clippy --all-targets --all-features --workspace -- -D warnings
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! - [tui-big-text]
 //! - [tui-box-text]
 //! - [tui-cards]
+//! - [tui-equalizer]
 //! - [tui-popup]
 //! - [tui-prompts]
 //! - [tui-qrcode]
@@ -38,6 +39,10 @@
 //!
 //! [![Demo](https://vhs.charm.sh/vhs-34mhPM1Juk2XnnLTGpOtE9.gif)][tui-cards]
 //!
+//! ## [tui-equalizer]
+//!
+//! [![Demo](https://vhs.charm.sh/vhs-FiRQkkDAUEnH2BrPbUx5i.gif)][tui-equalizer]
+//!
 //! ## [tui-popup]
 //!
 //! [![Demo](https://vhs.charm.sh/vhs-q5Kz0QP3zmrBlQ6dofjMh.gif)][tui-popup]
@@ -59,6 +64,7 @@
 //! [tui-big-text]: https://crates.io/crates/tui-big-text
 //! [tui-box-text]: https://crates.io/crates/tui-box-text
 //! [tui-cards]: https://crates.io/crates/tui-cards
+//! [tui-equalizer]: https://crates.io/crates/tui-equalizer
 //! [tui-popup]: https://crates.io/crates/tui-popup
 //! [tui-prompts]: https://crates.io/crates/tui-prompts
 //! [tui-qrcode]: https://crates.io/crates/tui-qrcode
@@ -78,6 +84,9 @@ pub use tui_box_text as box_text;
 #[cfg(feature = "cards")]
 #[doc(inline)]
 pub use tui_cards as cards;
+#[cfg(feature = "equalizer")]
+#[doc(inline)]
+pub use tui_equalizer as equalizer;
 #[cfg(feature = "popup")]
 #[doc(inline)]
 pub use tui_popup as popup;

--- a/tui-equalizer/Cargo.toml
+++ b/tui-equalizer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tui-equalizer"
+description = "An equalizer widget for Ratatui with multiple frequency bands."
+version = "0.2.0"
+documentation = "https://docs.rs/tui-equalizer"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ratatui-core.workspace = true
+
+[dev-dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+itertools.workspace = true
+rand.workspace = true
+ratatui = { workspace = true, default-features = true }

--- a/tui-equalizer/README.md
+++ b/tui-equalizer/README.md
@@ -1,0 +1,49 @@
+# tui-equalizer
+
+<!-- cargo-rdme start -->
+
+An equalizer widget for [Ratatui] with multiple frequency bands.
+
+The equalizer is a vertical bar chart where each band represents a frequency range. Each band
+can display a value from 0.0 to 1.0, where 1.0 is the maximum value.
+
+![Made with VHS](https://vhs.charm.sh/vhs-FiRQkkDAUEnH2BrPbUx5i.gif)
+
+This demo can be found in the examples folder in the git repo.
+
+```shell
+cargo run --example demo
+```
+
+Inspired by [a comment in the ratatui
+repo](https://github.com/ratatui/ratatui/issues/1325#issuecomment-2335095486).
+
+## Example
+
+```rust
+use tui_equalizer::{Band, Equalizer};
+
+let equalizer = Equalizer {
+    bands: vec![Band::from(0.5), Band::from(0.8), Band::from(0.3)],
+    brightness: 1.0,
+};
+equalizer.render(area, &mut buf);
+```
+
+## License
+
+Copyright (c) Josh McKinney
+
+This project is licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+[LICENSE-APACHE]: https://github.com/ratatui/tui-widgets/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/ratatui/tui-widgets/blob/main/LICENSE-MIT
+
+[Ratatui]: https://crates.io/crates/ratatui
+
+<!-- cargo-rdme end -->

--- a/tui-equalizer/examples/demo.rs
+++ b/tui-equalizer/examples/demo.rs
@@ -1,0 +1,92 @@
+use std::time::{Duration, Instant};
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use itertools::Itertools;
+use rand::{rng, RngExt};
+use ratatui::{DefaultTerminal, Frame};
+use tui_equalizer::{Band, Equalizer};
+
+const FRAMES_PER_SECOND: f64 = 60.0;
+
+// How often to randomly update the equalizer bands
+const UPDATE_INTERVAL: Duration = Duration::from_millis(500);
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    ratatui::run(run)
+}
+
+fn run(terminal: &mut DefaultTerminal) -> Result<()> {
+    let width = terminal.size()?.width;
+    let mut current_bands = random_bands(width);
+    let mut next_bands = random_bands(width);
+    let mut last_time = Instant::now();
+    loop {
+        let percent = last_time.elapsed().as_secs_f64() / UPDATE_INTERVAL.as_secs_f64();
+        let interpolated = interpolate(&current_bands, &next_bands, percent);
+        if percent >= 1.0 {
+            // Update the bands every 500ms
+            last_time = Instant::now();
+            current_bands = interpolated.clone();
+            next_bands = random_bands(width);
+        }
+        terminal.draw(|frame| render(frame, &current_bands, &interpolated))?;
+        if handle_input()? == Command::Quit {
+            break Ok(());
+        }
+    }
+}
+
+fn interpolate(current: &[Band], next: &[Band], percent: f64) -> Vec<Band> {
+    current
+        .iter()
+        .zip(next.iter())
+        .map(|(current, next)| Band {
+            value: current.value + (next.value - current.value) * percent.clamp(0.0, 1.0),
+        })
+        .collect_vec()
+}
+
+fn random_bands(count: u16) -> Vec<Band> {
+    (0..count / 2)
+        .map(|_| Band::from(rng().random_range(0.1..1.0)))
+        .collect_vec()
+}
+
+fn render(frame: &mut Frame, current: &[Band], bands: &[Band]) {
+    let size = frame.area();
+    frame.render_widget(
+        Equalizer {
+            bands: current.to_vec(),
+            brightness: 0.15,
+        },
+        size,
+    );
+    frame.render_widget(
+        Equalizer {
+            bands: bands.to_vec(),
+            brightness: 1.0,
+        },
+        size,
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Command {
+    Noop,
+    Quit,
+}
+
+fn handle_input() -> Result<Command> {
+    if !event::poll(Duration::from_secs_f64(1.0 / FRAMES_PER_SECOND))? {
+        return Ok(Command::Noop);
+    }
+    if let Some(key) = event::read()?.as_key_press_event() {
+        return match key.code {
+            KeyCode::Char('q') => Ok(Command::Quit),
+            _ => Ok(Command::Noop),
+        };
+    }
+    Ok(Command::Noop)
+}

--- a/tui-equalizer/src/lib.rs
+++ b/tui-equalizer/src/lib.rs
@@ -1,0 +1,126 @@
+//! An equalizer widget for [Ratatui] with multiple frequency bands.
+//!
+//! The equalizer is a vertical bar chart where each band represents a frequency range. Each band
+//! can display a value from 0.0 to 1.0, where 1.0 is the maximum value.
+//!
+//! ![Made with VHS](https://vhs.charm.sh/vhs-FiRQkkDAUEnH2BrPbUx5i.gif)
+//!
+//! This demo can be found in the examples folder in the git repo.
+//!
+//! ```shell
+//! cargo run --example demo
+//! ```
+//!
+//! Inspired by [a comment in the ratatui
+//! repo](https://github.com/ratatui/ratatui/issues/1325#issuecomment-2335095486).
+//!
+//! # Example
+//!
+//! ```rust
+//! # use ratatui::{widgets::Widget, layout::Rect, buffer::Buffer};
+//! # let area = Rect::default();
+//! # let mut buf = Buffer::empty(area);
+//! use tui_equalizer::{Band, Equalizer};
+//!
+//! let equalizer = Equalizer {
+//!     bands: vec![Band::from(0.5), Band::from(0.8), Band::from(0.3)],
+//!     brightness: 1.0,
+//! };
+//! equalizer.render(area, &mut buf);
+//! ```
+//!
+//! # License
+//!
+//! Copyright (c) Josh McKinney
+//!
+//! This project is licensed under either of:
+//!
+//! - Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+//! - MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>)
+//!
+//! at your option.
+//!
+//! [LICENSE-APACHE]: https://github.com/ratatui/tui-widgets/blob/main/LICENSE-APACHE
+//! [LICENSE-MIT]: https://github.com/ratatui/tui-widgets/blob/main/LICENSE-MIT
+//!
+//! [Ratatui]: https://crates.io/crates/ratatui
+
+use std::iter::zip;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Constraint, Layout, Rect};
+use ratatui_core::style::Color;
+use ratatui_core::symbols;
+use ratatui_core::widgets::Widget;
+
+/// An equalizer widget with multiple frequency bands.
+///
+/// The equalizer is a vertical bar chart where each band represents a frequency range.
+///
+/// # Example
+///
+/// ```
+/// # use ratatui::widgets::Widget;
+/// # let area = ratatui::layout::Rect::default();
+/// # let mut buf = ratatui::buffer::Buffer::empty(area);
+/// use tui_equalizer::{Band, Equalizer};
+///
+/// let equalizer = Equalizer {
+///     bands: vec![Band::from(0.5), Band::from(0.8), Band::from(0.3)],
+///     brightness: 1.0,
+/// };
+/// equalizer.render(area, &mut buf);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Equalizer {
+    /// A vector of `Band` structs representing each frequency band.
+    pub bands: Vec<Band>,
+    pub brightness: f64,
+}
+
+/// A struct representing a single frequency band in the equalizer.
+#[derive(Debug, Clone)]
+pub struct Band {
+    /// The normalized value of the band, where the maximum is 1.0.
+    pub value: f64,
+}
+
+impl From<f64> for Band {
+    fn from(value: f64) -> Self {
+        Self { value }
+    }
+}
+
+impl Widget for Equalizer {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let areas = Layout::horizontal(vec![Constraint::Length(2); self.bands.len()]).split(area);
+        for (band, area) in zip(self.bands, areas.iter()) {
+            band.render(*area, buf, self.brightness);
+        }
+    }
+}
+
+impl Band {
+    fn render(self, area: Rect, buf: &mut Buffer, brightness: f64) {
+        let value = self.value.clamp(0.0, 1.0);
+        let height = (value * area.height as f64) as u16;
+
+        // Calculate the color gradient step
+        let color_step = 1.0 / area.height as f64;
+
+        // Iterate over each segment and render it with the corresponding color
+        for i in 0..height {
+            // Green to Yellow to Red gradient
+            let v = i as f64 * color_step;
+            let vv = 1.0 - v;
+            let br = brightness.clamp(0.0, 1.0) * 255.0;
+            let r = if v < 0.5 { v * 2.0 * br } else { br } as u8;
+            let g = if v < 0.5 { br } else { vv * 2.0 * br } as u8;
+            let b = 0;
+            let color = Color::Rgb(r, g, b);
+            buf[(area.left(), area.bottom().saturating_sub(i + 1))]
+                .set_fg(color)
+                .set_symbol(symbols::bar::HALF);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- import the standalone `tui-equalizer` history via an unrelated-history merge after moving its files under `tui-equalizer/`
- integrate `tui-equalizer` as a workspace crate and expose it through the root `equalizer` feature and facade re-export
- wire the crate into README generation, release-plz, root docs, and local `just rdme-check`
- remove imported repo-level metadata that does not belong inside a workspace member

## History shape

- original imported `tui-equalizer` tip preserved: `855f1cc7e209`
- move commit in imported side: `167a5a2e6a63`
- import merge commit: `f81ea1a8bb27`
- workspace integration commit: `880858b95c48`

## Validation

- `just fmt-check`
- `just rdme-check`
- `markdownlint-cli2 "**/*.md"`
- `cargo check --all-targets --all-features --workspace`
- `cargo test --all-features --workspace`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo doc --all-features --workspace`
- `typos`
- `actionlint`
- `zizmor .github/workflows`
- `cargo deny --all-features check advisories bans licenses sources`
- `cargo semver-checks --workspace`
- `cargo +1.88.0 check --all-features --workspace`

Note: `cargo doc` still emits pre-existing unresolved `[Ratatui]` link warnings in `tui-box-text`, `tui-cards`, and `tui-popup`; `tui-equalizer` is clean.
