### PR TITLE
docs: modernize tui-bar-graph examples

### DIFF
--- a/tui-bar-graph/examples/simple-bar-graph.rs
+++ b/tui-bar-graph/examples/simple-bar-graph.rs
@@ -5,13 +5,10 @@ use tui_bar_graph::{BarGraph, BarStyle, ColorMode};
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = run(terminal);
-    ratatui::restore();
-    result
+    ratatui::run(run)
 }
 
-fn run(mut terminal: DefaultTerminal) -> color_eyre::Result<()> {
+fn run(terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
     loop {
         terminal.draw(render)?;
         if matches!(

--- a/tui-bar-graph/examples/tui-bar-graph.rs
+++ b/tui-bar-graph/examples/tui-bar-graph.rs
@@ -50,13 +50,10 @@ impl Preset {
 fn main() -> color_eyre::Result<()> {
     let args = Args::parse();
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = run(terminal, &args);
-    ratatui::restore();
-    result
+    ratatui::run(|terminal| run(terminal, &args))
 }
 
-fn run(mut terminal: DefaultTerminal, args: &Args) -> color_eyre::Result<()> {
+fn run(terminal: &mut DefaultTerminal, args: &Args) -> color_eyre::Result<()> {
     loop {
         terminal.draw(|frame| render(frame, args))?;
         if matches!(


### PR DESCRIPTION
## Summary
- use ratatui::run in the tui-bar-graph examples
- keep CLI parsing, rendering behavior, and key handling unchanged

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-bar-graph --examples --all-features
- cargo clippy -p tui-bar-graph --examples --all-features -- -D warnings