### PR TITLE
docs: modernize tui-popup examples

### DIFF
--- a/tui-popup/examples/paragraph.rs
+++ b/tui-popup/examples/paragraph.rs
@@ -1,17 +1,14 @@
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::Frame;
-use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::crossterm::event::{self, KeyCode};
 use ratatui::prelude::{Rect, Span, Style, Stylize, Text};
 use ratatui::widgets::{Paragraph, Wrap};
 use tui_popup::{KnownSizeWrapper, Popup};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = App::default().run(terminal);
-    ratatui::restore();
-    result
+    ratatui::run(|terminal| App::default().run(terminal))
 }
 
 #[derive(Default)]
@@ -22,7 +19,7 @@ struct App {
 }
 
 impl App {
-    fn run(&mut self, mut terminal: ratatui::DefaultTerminal) -> Result<()> {
+    fn run(&mut self, terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
         self.lorem_ipsum = lipsum(2000);
         while !self.should_exit {
             terminal.draw(|frame| self.render(frame))?;
@@ -58,7 +55,7 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        if let Event::Key(key) = event::read()? {
+        if let Some(key) = event::read()?.as_key_press_event() {
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => self.should_exit = true,
                 KeyCode::Char('j') | KeyCode::Down => self.scroll_down(),

--- a/tui-popup/examples/popup.rs
+++ b/tui-popup/examples/popup.rs
@@ -1,25 +1,22 @@
 use color_eyre::Result;
 use lipsum::lipsum;
-use ratatui::Frame;
-use ratatui::crossterm::event::{self, Event};
+use ratatui::crossterm::event;
 use ratatui::prelude::{Rect, Style, Stylize};
 use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::{DefaultTerminal, Frame};
 use tui_popup::Popup;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let mut terminal = ratatui::init();
-    let result = run(&mut terminal);
-    ratatui::restore();
-    result
+    ratatui::run(run)
 }
 
-fn run(terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
+fn run(terminal: &mut DefaultTerminal) -> Result<()> {
     loop {
         terminal.draw(|frame| {
             render(frame);
         })?;
-        if matches!(event::read()?, Event::Key(_)) {
+        if event::read()?.as_key_press_event().is_some() {
             break Ok(());
         }
     }

--- a/tui-popup/examples/state.rs
+++ b/tui-popup/examples/state.rs
@@ -1,20 +1,17 @@
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::DefaultTerminal;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent};
 use ratatui::prelude::{Constraint, Frame, Layout, Rect, Style, Stylize, Text};
 use ratatui::widgets::{Paragraph, Wrap};
 use tui_popup::{Popup, PopupState};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = run(terminal);
-    ratatui::restore();
-    result
+    ratatui::run(run)
 }
 
-fn run(mut terminal: DefaultTerminal) -> Result<()> {
+fn run(terminal: &mut DefaultTerminal) -> Result<()> {
     let mut state = PopupState::default();
     let mut exit = false;
     while !exit {
@@ -67,12 +64,11 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &PopupState) {
 }
 
 fn handle_events(popup: &mut PopupState, exit: &mut bool) -> Result<()> {
-    match event::read()? {
-        Event::Key(event) if event.kind == KeyEventKind::Press => {
-            handle_key_event(event, popup, exit);
-        }
-        Event::Mouse(event) => popup.handle_mouse_event(event),
-        _ => (),
+    let event = event::read()?;
+    if let Some(key) = event.as_key_press_event() {
+        handle_key_event(key, popup, exit);
+    } else if let Event::Mouse(event) = event {
+        popup.handle_mouse_event(event);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- use ratatui::run in the tui-popup examples
- borrow DefaultTerminal in example run loops
- handle key presses with as_key_press_event while preserving mouse handling in the state example

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-popup --examples --all-features
- cargo clippy -p tui-popup --examples --all-features -- -D warnings
- just rdme-check