### PR TITLE
docs: install color-eyre in stopwatch example

### DIFF
--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -15,6 +15,7 @@ use tui_big_text::BigText;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    color_eyre::install()?;
     let mut app = StopwatchApp::default();
     let mut terminal = ratatui::init();
     let result = app.run(&mut terminal).await;


### PR DESCRIPTION
## Summary
- install color-eyre before running the tui-big-text stopwatch example
- keep the stopwatch lifecycle and behavior unchanged

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-big-text --examples --all-features
- cargo clippy -p tui-big-text --examples --all-features -- -D warnings