### PR TITLE
docs: modernize tui-qrcode example

### DIFF
--- a/tui-qrcode/examples/qrcode.rs
+++ b/tui-qrcode/examples/qrcode.rs
@@ -5,16 +5,13 @@ use tui_qrcode::{Colors, QrCodeWidget};
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = run(terminal);
-    ratatui::restore();
-    result
+    ratatui::run(run)
 }
 
-fn run(mut terminal: DefaultTerminal) -> color_eyre::Result<()> {
+fn run(terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
     loop {
         terminal.draw(render)?;
-        if matches!(event::read()?, event::Event::Key(_)) {
+        if event::read()?.as_key_press_event().is_some() {
             break Ok(());
         }
     }


### PR DESCRIPTION
## Summary
- use ratatui::run in the tui-qrcode example
- borrow DefaultTerminal in the run loop
- handle key presses with as_key_press_event while preserving any-key exit behavior

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-qrcode --examples --all-features
- cargo clippy -p tui-qrcode --examples --all-features -- -D warnings