### PR TITLE
docs: modernize tui-scrollbar examples

### DIFF
--- a/tui-scrollbar/examples/scrollbar.rs
+++ b/tui-scrollbar/examples/scrollbar.rs
@@ -19,17 +19,14 @@
 
 use color_eyre::Result;
 use ratatui::DefaultTerminal;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{self, KeyCode};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::Paragraph;
 use tui_scrollbar::{SUBCELL, ScrollBar, ScrollBarArrows, ScrollLengths, ScrollMetrics};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let result = App::new().run(terminal);
-    ratatui::restore();
-    result
+    ratatui::run(|terminal| App::new().run(terminal))
 }
 
 #[derive(Debug, Default)]
@@ -56,7 +53,7 @@ impl App {
     }
 
     /// Runs the draw loop until a quit key is pressed.
-    fn run(&mut self, mut terminal: DefaultTerminal) -> Result<()> {
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> Result<()> {
         while self.state == AppState::Running {
             terminal.draw(|frame| {
                 render_scrollbars(frame.area(), frame);
@@ -68,8 +65,7 @@ impl App {
 
     /// Handles a single input event and updates the run state.
     fn handle_events(&mut self) -> Result<()> {
-        if let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
+        if let Some(key) = event::read()?.as_key_press_event()
             && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
         {
             self.state = AppState::Quit;

--- a/tui-scrollbar/examples/scrollbar_mouse.rs
+++ b/tui-scrollbar/examples/scrollbar_mouse.rs
@@ -29,7 +29,7 @@ use std::io;
 
 use color_eyre::Result;
 use ratatui::DefaultTerminal;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{self, Event, KeyCode};
 use ratatui::crossterm::execute;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style, Stylize};
@@ -52,12 +52,12 @@ const SCROLLBAR_ARROW_FG: Color = Color::Rgb(224, 224, 224);
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let mut terminal = ratatui::init();
-    execute!(io::stdout(), event::EnableMouseCapture)?;
-    let result = App::new().run(&mut terminal);
-    execute!(io::stdout(), event::DisableMouseCapture)?;
-    ratatui::restore();
-    result
+    ratatui::run(|terminal| {
+        execute!(io::stdout(), event::EnableMouseCapture)?;
+        let result = App::new().run(terminal);
+        execute!(io::stdout(), event::DisableMouseCapture)?;
+        result
+    })
 }
 
 #[derive(Debug, Default)]
@@ -221,15 +221,8 @@ impl App {
     fn handle_events(&mut self) -> Result<()> {
         match event::read()? {
             Event::Key(key) => {
-                if key.kind == KeyEventKind::Press {
-                    match key.code {
-                        KeyCode::Char('q') | KeyCode::Esc => self.state = AppState::Quit,
-                        KeyCode::Up => self.handle_key_scroll(0, -(KEY_STEP as isize)),
-                        KeyCode::Down => self.handle_key_scroll(0, KEY_STEP as isize),
-                        KeyCode::Left => self.handle_key_scroll(-(KEY_STEP as isize), 0),
-                        KeyCode::Right => self.handle_key_scroll(KEY_STEP as isize, 0),
-                        _ => {}
-                    }
+                if key.is_press() {
+                    self.handle_key_event(key.code);
                 }
             }
             Event::Mouse(event) => {
@@ -238,6 +231,18 @@ impl App {
             _ => {}
         }
         Ok(())
+    }
+
+    /// Handles keyboard input, updating offsets or exiting as needed.
+    fn handle_key_event(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => self.state = AppState::Quit,
+            KeyCode::Up | KeyCode::Char('k') => self.handle_key_scroll(0, -(KEY_STEP as isize)),
+            KeyCode::Down | KeyCode::Char('j') => self.handle_key_scroll(0, KEY_STEP as isize),
+            KeyCode::Left | KeyCode::Char('h') => self.handle_key_scroll(-(KEY_STEP as isize), 0),
+            KeyCode::Right | KeyCode::Char('l') => self.handle_key_scroll(KEY_STEP as isize, 0),
+            _ => {}
+        }
     }
 
     /// Applies a keyboard delta to the scrollbar offsets.

--- a/tui-scrollbar/examples/scrollbar_styled.rs
+++ b/tui-scrollbar/examples/scrollbar_styled.rs
@@ -12,11 +12,11 @@ use tui_scrollbar::{GlyphSet, ScrollBar, ScrollBarArrows, ScrollLengths};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let mut terminal = ratatui::init();
-    terminal.draw(|frame| render(frame.area(), frame))?;
-    std::thread::sleep(Duration::from_secs(3));
-    ratatui::restore();
-    Ok(())
+    ratatui::run(|terminal| {
+        terminal.draw(|frame| render(frame.area(), frame))?;
+        std::thread::sleep(Duration::from_secs(3));
+        Ok(())
+    })
 }
 
 fn render(area: Rect, frame: &mut ratatui::Frame) {


### PR DESCRIPTION
## Summary
- use ratatui::run in the tui-scrollbar examples
- borrow DefaultTerminal in example run loops
- preserve mouse capture setup while using current key press helpers
- add q/Esc exit consistency and vim motion keys for the mouse example

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-scrollbar --examples --all-features
- cargo clippy -p tui-scrollbar --examples --all-features -- -D warnings
- just rdme-check