### PR TITLE
fix: ignore non-press key events in examples

### DIFF
--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -284,7 +284,7 @@ impl EventHandler {
         event: Option<core::result::Result<event::Event, std::io::Error>>,
     ) -> Result<Message> {
         match event {
-            Some(Ok(event::Event::Key(key))) => Ok(match key.code {
+            Some(Ok(event::Event::Key(key))) if key.is_press() => Ok(match key.code {
                 KeyCode::Char('q') => Message::Quit,
                 KeyCode::Char(' ') => Message::StartOrSplit,
                 KeyCode::Char('s') | KeyCode::Enter => Message::Stop,


### PR DESCRIPTION
## Summary
- ignore release and repeat key events in the tui-big-text stopwatch example
- confirm the remaining examples already filter key handling to press events

## Validation
- cargo +nightly fmt --all
- cargo check -p tui-big-text --examples --all-features
- cargo clippy -p tui-big-text --examples --all-features -- -D warnings
- just rdme-check