### PR TITLE
docs: document widget examples

### DIFF
--- a/tui-bar-graph/examples/simple-bar-graph.rs
+++ b/tui-bar-graph/examples/simple-bar-graph.rs
@@ -1,3 +1,13 @@
+//! Renders a full-screen bar graph with random values and a vertical color gradient.
+//!
+//! Run with `cargo run -p tui-bar-graph --example simple-bar-graph`.
+//!
+//! This focused example uses `BarStyle::Braille`, which can draw two data points per terminal
+//! column. The data length is therefore twice the frame width so each braille half-cell has a
+//! value to render.
+//!
+//! Press any key to quit. Rerun the example to generate a different random graph.
+
 use crossterm::event::{self, Event, KeyEvent, KeyEventKind};
 use rand::RngExt;
 use ratatui::{DefaultTerminal, Frame};
@@ -24,6 +34,7 @@ fn run(terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
 }
 
 fn render(frame: &mut Frame) {
+    // Braille bars render two horizontal samples in each terminal cell.
     let data_count = frame.area().width as usize * 2;
     let mut rng = rand::rng();
     let data: Vec<f64> = std::iter::repeat_with(|| rng.random())

--- a/tui-bar-graph/examples/tui-bar-graph.rs
+++ b/tui-bar-graph/examples/tui-bar-graph.rs
@@ -1,3 +1,13 @@
+//! Demonstrates configurable bar graph rendering from command-line arguments.
+//!
+//! Run with `cargo run -p tui-bar-graph --example tui-bar-graph -- quadrant viridis`.
+//!
+//! This is a survey example for comparing `BarStyle` resolution and `colorgrad` presets. The
+//! example adjusts the generated data length to match each style: solid bars use one value per
+//! column, octant and braille bars use two, and quadrant bars use four.
+//!
+//! Press any key to quit.
+
 use clap::{Parser, ValueEnum};
 use colorgrad::Gradient;
 use crossterm::event::{self, Event, KeyEvent, KeyEventKind};
@@ -93,6 +103,7 @@ fn render(frame: &mut Frame, args: &Args) {
     frame.render_widget(&block, frame.area());
 
     let area = block.inner(frame.area());
+    // Match the data count to the selected glyph resolution so the graph fills the width.
     let width = match args.bar_style {
         BarStyle::Solid => area.width as usize,
         BarStyle::Octant | BarStyle::Braille => area.width as usize * 2,

--- a/tui-big-text/examples/alignment.rs
+++ b/tui-big-text/examples/alignment.rs
@@ -1,3 +1,12 @@
+//! Demonstrates left, center, and right alignment for `BigText`.
+//!
+//! Run with `cargo run -p tui-big-text --example alignment`.
+//!
+//! Each widget receives the full row width for its section. The alignment methods change where the
+//! rendered glyphs sit inside that area; they do not change the area Ratatui gives to the widget.
+//!
+//! Press `q` or `Esc` to quit.
+
 use color_eyre::Result;
 use crossterm::event::{self, KeyCode};
 use ratatui::layout::{Constraint, Layout, Offset};

--- a/tui-big-text/examples/big_text.rs
+++ b/tui-big-text/examples/big_text.rs
@@ -1,3 +1,12 @@
+//! Renders a basic `BigText` widget with per-line styling.
+//!
+//! Run with `cargo run -p tui-big-text --example big_text`.
+//!
+//! The builder-level style is blue, while individual `Line` styles override it. This shows the
+//! same styling precedence callers get when mixing widget defaults with styled text spans.
+//!
+//! Press `q` or `Esc` to quit.
+
 use color_eyre::Result;
 use crossterm::event::{self, KeyCode};
 use ratatui::layout::Offset;

--- a/tui-big-text/examples/pixel_size.rs
+++ b/tui-big-text/examples/pixel_size.rs
@@ -1,3 +1,13 @@
+//! Compares the available `PixelSize` variants for `BigText`.
+//!
+//! Run with `cargo run -p tui-big-text --example pixel_size`.
+//!
+//! The examples use fixed-height rows because each pixel size consumes a different number of
+//! terminal rows. If a terminal is too short, the lower variants are clipped by the frame boundary
+//! rather than resized.
+//!
+//! Press `q` or `Esc` to quit.
+
 use color_eyre::Result;
 use crossterm::event::{self, KeyCode};
 use ratatui::prelude::*;
@@ -64,8 +74,9 @@ fn render(frame: &mut Frame) {
         .lines(vec!["Octant".magenta().into(), " 1/2*1/4".magenta().into()])
         .build();
 
-    // Setup layout for the title and 8 blocks
     use Constraint::*;
+    // Each pixel size has a fixed cell footprint, so the rows reserve the height each variant
+    // needs rather than asking BigText to scale to the available area.
     let [top, full, half_height, upper_middle, lower_middle, bottom] = Layout::vertical([
         Length(2),
         Length(8),

--- a/tui-big-text/examples/stopwatch.rs
+++ b/tui-big-text/examples/stopwatch.rs
@@ -1,3 +1,16 @@
+//! Runs an async stopwatch example using `BigText` for the timer display.
+//!
+//! Run with `cargo run -p tui-big-text --example stopwatch`.
+//!
+//! The event handler combines crossterm's async event stream with a fixed tick interval. Key
+//! events update the stopwatch state, while tick messages redraw the timer and FPS counter even
+//! when no input arrives.
+//!
+//! Controls:
+//! - `Space`: start the stopwatch or record a split
+//! - `Enter` / `s`: stop the stopwatch
+//! - `q`: quit
+
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;

--- a/tui-box-text/README.md
+++ b/tui-box-text/README.md
@@ -51,6 +51,7 @@ For the full suite of widgets, see [tui-widgets].
 [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-box-text/CHANGELOG.md
 [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
 [Joshka]: https://github.com/joshka
+[Ratatui]: https://ratatui.rs
 [tui-widgets]: https://crates.io/crates/tui-widgets
 
 <!-- cargo-rdme end -->

--- a/tui-box-text/examples/box_text.rs
+++ b/tui-box-text/examples/box_text.rs
@@ -1,3 +1,12 @@
+//! Renders printable ASCII characters as box-drawing text.
+//!
+//! Run with `cargo run -p tui-box-text --example box_text`.
+//!
+//! Each `BoxChar` is rendered into a 4x3 cell so the example can show the full glyph shape for
+//! every printable character. Smaller areas clip the generated box glyphs.
+//!
+//! Press `q` or `Esc` to quit.
+
 use std::iter::zip;
 
 use ratatui::crossterm::event::{self, KeyCode};
@@ -29,6 +38,7 @@ fn draw(frame: &mut Frame) {
         Line::from("Tui-box-text. Press Esc to exit").centered(),
         header,
     );
+    // BoxChar glyphs are at most four columns wide and three rows tall.
     let mut areas = Vec::new();
     for y in (body.top() + 3..body.bottom()).step_by(3) {
         for x in (body.left() + 4..body.right()).step_by(4) {

--- a/tui-box-text/src/lib.rs
+++ b/tui-box-text/src/lib.rs
@@ -49,6 +49,7 @@
 //! [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-box-text/CHANGELOG.md
 //! [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
 //! [Joshka]: https://github.com/joshka
+//! [Ratatui]: https://ratatui.rs
 //! [tui-widgets]: https://crates.io/crates/tui-widgets
 
 use std::collections::HashMap;

--- a/tui-cards/README.md
+++ b/tui-cards/README.md
@@ -57,6 +57,7 @@ For the full suite of widgets, see [tui-widgets].
 [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-cards/CHANGELOG.md
 [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
 [Joshka]: https://github.com/joshka
+[Ratatui]: https://ratatui.rs
 [tui-widgets]: https://crates.io/crates/tui-widgets
 
 <!-- cargo-rdme end -->

--- a/tui-cards/examples/card.rs
+++ b/tui-cards/examples/card.rs
@@ -1,3 +1,13 @@
+//! Renders a grid of playing-card widgets for every suit and rank.
+//!
+//! Run with `cargo run -p tui-cards --example card`.
+//!
+//! Cards are drawn into 15x10 cells, so the example truncates the terminal area to whole-card
+//! multiples before placing the grid. Extra rows or columns are left unused instead of drawing
+//! partial cards.
+//!
+//! Press `q` or `Esc` to quit.
+
 use itertools::Itertools;
 use ratatui::crossterm::event::{self, KeyCode};
 use ratatui::layout::Rect;
@@ -23,6 +33,7 @@ fn run(terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
 }
 
 fn draw(frame: &mut Frame) {
+    // Cards are designed for a 15x10 cell; leave partial cells unused.
     let width = frame.area().width / 15 * 15;
     let height = frame.area().height / 10 * 10;
     let cards = Suit::iter()

--- a/tui-cards/src/lib.rs
+++ b/tui-cards/src/lib.rs
@@ -55,6 +55,7 @@
 //! [Changelog]: https://github.com/ratatui/tui-widgets/blob/main/tui-cards/CHANGELOG.md
 //! [Contributing]: https://github.com/ratatui/tui-widgets/blob/main/CONTRIBUTING.md
 //! [Joshka]: https://github.com/joshka
+//! [Ratatui]: https://ratatui.rs
 //! [tui-widgets]: https://crates.io/crates/tui-widgets
 use std::iter::zip;
 

--- a/tui-equalizer/examples/demo.rs
+++ b/tui-equalizer/examples/demo.rs
@@ -1,3 +1,13 @@
+//! Animates two overlaid equalizer widgets with interpolated random bands.
+//!
+//! Run with `cargo run -p tui-equalizer --example demo`.
+//!
+//! One low-brightness equalizer keeps the previous band values visible while a second equalizer
+//! renders the interpolated values at full brightness. The overlay makes the transition between
+//! random targets visible without adding state to the widget itself.
+//!
+//! Press `q` to quit.
+
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;
@@ -56,6 +66,8 @@ fn random_bands(count: u16) -> Vec<Band> {
 
 fn render(frame: &mut Frame, current: &[Band], bands: &[Band]) {
     let size = frame.area();
+    // Draw the previous target first as a dim trail, then the interpolated values at full
+    // brightness.
     frame.render_widget(
         Equalizer {
             bands: current.to_vec(),

--- a/tui-popup/README.md
+++ b/tui-popup/README.md
@@ -163,6 +163,7 @@ For the full suite of widgets, see [tui-widgets].
 [tui-scrollview]: https://crates.io/crates/tui-scrollview
 
 [Joshka]: https://github.com/joshka
+[Ratatui]: https://ratatui.rs
 [tui-widgets]: https://crates.io/crates/tui-widgets
 
 <!-- cargo-rdme end -->

--- a/tui-popup/examples/paragraph.rs
+++ b/tui-popup/examples/paragraph.rs
@@ -1,3 +1,16 @@
+//! Shows a popup containing a fixed-size scrollable paragraph.
+//!
+//! Run with `cargo run -p tui-popup --example paragraph --features crossterm`.
+//!
+//! `Paragraph` does not report its desired popup size, so the example wraps it in
+//! `KnownSizeWrapper`. The wrapper gives `Popup` a stable width and height while the paragraph
+//! keeps its own scroll offset.
+//!
+//! Controls:
+//! - `j` / `Down`: scroll down
+//! - `k` / `Up`: scroll up
+//! - `q` / `Esc`: quit
+
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::Frame;
@@ -43,6 +56,8 @@ impl App {
     fn render_popup(&self, frame: &mut Frame) {
         let lines: Text = (0..10).map(|i| Span::raw(format!("Line {i}"))).collect();
         let paragraph = Paragraph::new(lines).scroll((self.scroll, 0));
+        // Popup needs KnownSize for placement; Paragraph owns the scroll offset but not a desired
+        // size.
         let wrapper = KnownSizeWrapper {
             inner: paragraph,
             width: 21,

--- a/tui-popup/examples/popup.rs
+++ b/tui-popup/examples/popup.rs
@@ -1,3 +1,12 @@
+//! Renders a basic centered popup over wrapped background text.
+//!
+//! Run with `cargo run -p tui-popup --example popup --features crossterm`.
+//!
+//! This is the minimal popup example: `Popup::new` receives plain text, centers it in the frame,
+//! and lets the popup size itself from the content.
+//!
+//! Press any key to quit.
+
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::crossterm::event;

--- a/tui-popup/examples/state.rs
+++ b/tui-popup/examples/state.rs
@@ -1,3 +1,19 @@
+//! Demonstrates `PopupState` by moving a popup with keyboard and mouse input.
+//!
+//! Run with `cargo run -p tui-popup --example state --features crossterm`.
+//!
+//! `PopupState` stores the popup area from the last render. The status bar prints that area so you
+//! can see how keyboard moves, mouse drags, and reset commands change the state used by the next
+//! frame.
+//!
+//! Controls:
+//! - `h` / `Left`: move left
+//! - `j` / `Down`: move down
+//! - `k` / `Up`: move up
+//! - `l` / `Right`: move right
+//! - `r`: reset popup state
+//! - `q` / `Esc`: quit
+
 use color_eyre::Result;
 use lipsum::lipsum;
 use ratatui::DefaultTerminal;

--- a/tui-popup/src/lib.rs
+++ b/tui-popup/src/lib.rs
@@ -165,6 +165,7 @@
 //! [tui-scrollview]: https://crates.io/crates/tui-scrollview
 //!
 //! [Joshka]: https://github.com/joshka
+//! [Ratatui]: https://ratatui.rs
 //! [tui-widgets]: https://crates.io/crates/tui-widgets
 #![cfg_attr(docsrs, doc = "\n# Feature flags\n")]
 #![cfg_attr(docsrs, doc = document_features::document_features!())]

--- a/tui-prompts/examples/multi_line.rs
+++ b/tui-prompts/examples/multi_line.rs
@@ -1,3 +1,13 @@
+//! Demonstrates a multi-line text prompt.
+//!
+//! Run with `cargo run -p tui-prompts --example multi_line`.
+//!
+//! The prompt uses a bottom and right border to make the editable area visible while text wraps
+//! across multiple rows. The app exits only after the prompt state reports completion.
+//!
+//! Use the prompt's normal text-editing keys to enter text. Run with `--debug` to show prompt
+//! state while editing.
+
 use std::thread::sleep;
 use std::time::Duration;
 

--- a/tui-prompts/examples/text.rs
+++ b/tui-prompts/examples/text.rs
@@ -1,3 +1,18 @@
+//! Demonstrates several text prompt render styles in one form.
+//!
+//! Run with `cargo run -p tui-prompts --example text`.
+//!
+//! The three fields share the same `TextPrompt` state model but render the value differently:
+//! normal text, password masking, and invisible input. Focus moves between independent
+//! `TextState` values, and the app exits after all fields are submitted.
+//!
+//! Controls:
+//! - `Tab`: focus the next prompt
+//! - `Shift+Tab`: focus the previous prompt
+//! - `Enter`: submit the focused prompt
+//!
+//! Run with `--debug` to show prompt state while editing.
+
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -104,6 +119,7 @@ impl<'a> App<'a> {
     }
 
     fn draw_text_prompt(&mut self, frame: &mut Frame, username_area: Rect) {
+        // All three prompts use TextState; the render style only changes what is shown.
         TextPrompt::from("Username").draw(frame, username_area, &mut self.username_state);
     }
 

--- a/tui-qrcode/examples/qrcode.rs
+++ b/tui-qrcode/examples/qrcode.rs
@@ -1,3 +1,11 @@
+//! Renders a QR code for <https://ratatui.rs>.
+//!
+//! Run with `cargo run -p tui-qrcode --example qrcode`.
+//!
+//! The example uses inverted colors to render a white-on-black QR code.
+//!
+//! Press any key to quit.
+
 use qrcode::QrCode;
 use ratatui::crossterm::event;
 use ratatui::{DefaultTerminal, Frame};

--- a/tui-scrollbar/examples/scrollbar.rs
+++ b/tui-scrollbar/examples/scrollbar.rs
@@ -1,5 +1,7 @@
 //! Fractional scrollbar step showcase.
 //!
+//! Run with `cargo run -p tui-scrollbar --example scrollbar`.
+//!
 //! This example renders every 1/8th thumb step for both horizontal and vertical scrollbars so
 //! you can visually compare partial glyphs and track alignment.
 //!

--- a/tui-scrollbar/examples/scrollbar_mouse.rs
+++ b/tui-scrollbar/examples/scrollbar_mouse.rs
@@ -1,5 +1,7 @@
 //! Mouse + keyboard-driven scrollbar demo with smooth subcell movement.
 //!
+//! Run with `cargo run -p tui-scrollbar --example scrollbar_mouse --features crossterm`.
+//!
 //! If you are new to this crate, this is the fastest way to see the full interaction model:
 //! a horizontal scrollbar on the bottom edge and a vertical scrollbar on the right edge, both
 //! wired to the same input flow your app would use. The example keeps the scroll offsets in app

--- a/tui-scrollbar/examples/scrollbar_styled.rs
+++ b/tui-scrollbar/examples/scrollbar_styled.rs
@@ -1,5 +1,7 @@
 //! Styled scrollbar showcase.
 //!
+//! Run with `cargo run -p tui-scrollbar --example scrollbar_styled`.
+//!
 //! This example renders a static layout with independently styled track, thumb, and arrow glyphs.
 
 use std::time::Duration;

--- a/tui-scrollview/examples/horizontal.rs
+++ b/tui-scrollview/examples/horizontal.rs
@@ -1,7 +1,11 @@
 //! Demonstrates horizontal and vertical scrolling in the same `ScrollView`.
 //!
+//! Run with `cargo run -p tui-scrollview --example horizontal`.
+//!
 //! The content is twice as wide as the terminal and usually taller than the viewport, so this
 //! example is useful for checking that both scrollbars update correctly.
+//! `ScrollViewState` stores both offsets; the `ScrollView` clips the larger virtual buffer to the
+//! current frame area on each draw.
 //!
 //! Controls:
 //! - `h` / `Left`: scroll left
@@ -65,6 +69,7 @@ impl App {
     fn draw(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
         terminal.draw(|frame| {
             let area = frame.area();
+            // Make the virtual buffer wider than the viewport so horizontal scrolling is visible.
             let size = Size::new(area.width * 2, area.width);
             let mut scroll_view = ScrollView::new(size);
             let paragraph = Paragraph::new(self.text.clone()).wrap(Wrap::default());

--- a/tui-scrollview/examples/scrollview.rs
+++ b/tui-scrollview/examples/scrollview.rs
@@ -1,7 +1,11 @@
 //! Demonstrates a `ScrollView` containing multiple widgets rendered into an offscreen buffer.
 //!
+//! Run with `cargo run -p tui-scrollview --example scrollview`.
+//!
 //! This example builds a taller virtual area, renders several widgets into it, and then lets
 //! `ScrollViewState` decide which part of that content is visible in the terminal.
+//! The content width leaves room for a vertical scrollbar when the virtual height is taller than
+//! the viewport.
 //!
 //! Controls:
 //! - `j` / `Down`: scroll down
@@ -103,6 +107,7 @@ impl Widget for &mut App {
         let [title, body] = layout.areas(area);
 
         self.title().render(title, buf);
+        // When the virtual height overflows, reserve one column for the vertical scrollbar.
         let width = if buf.area.height < SCROLLVIEW_HEIGHT {
             buf.area.width - 1
         } else {

--- a/tui-scrollview/examples/tabs.rs
+++ b/tui-scrollview/examples/tabs.rs
@@ -1,9 +1,13 @@
 //! An example of using multiple tabs each with a scrollable view, as well as how state can be
 //! managed across multiple tabs using Stateful Widgets.
 //!
+//! Run with `cargo run -p tui-scrollview --example tabs --features ratatui/unstable-widget-ref`.
+//!
 //! This example uses the `unstable-widget-ref` feature in Ratatui to allow the tab widgets to
 //! be created once and then reused across multiple frames. Each tab has some static lorem ipsum
 //! text, and we store the scroll state for each tab separately.
+//! Switching tabs changes the visible widget, but it does not reset the hidden tabs' scroll
+//! offsets.
 //!
 //! Controls:
 //! - `Tab`: move to the next tab
@@ -149,6 +153,7 @@ impl App {
     fn handle_events(&mut self) -> Result<()> {
         use KeyCode::*;
         if let Some(key) = event::read()?.as_key_press_event() {
+            // Scroll commands apply only to the visible tab's state.
             let (_widget, scroll_view_state) = self
                 .tabs
                 .get_mut(&self.visible_tab)


### PR DESCRIPTION
## Summary

- add run commands and widget-specific context to the example module docs
- add targeted inline comments for non-obvious example sizing, state, and rendering choices
- fix broken crate-root `Ratatui` reference links that surfaced during docs validation

## Validation

- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --examples --all-features -- -D warnings`
- `cargo doc --workspace --examples --all-features --no-deps`

`cargo doc` still reports the existing `tui-bar-graph` example/lib output filename collision.
