### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,189 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.7] - 2026-06-14
+
+### 🐛 Bug Fixes
+
+- Ignore non-press key events in examples ([#284](https://github.com/ratatui/tui-widgets/issues/284))
+  > ## Summary
+  > - ignore release and repeat key events in the tui-big-text stopwatch
+  > example
+  > - confirm the remaining examples already filter key handling to press
+  > events
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+  > - just rdme-check
+
+### 📚 Documentation
+
+- Modernize tui-bar-graph examples ([#275](https://github.com/ratatui/tui-widgets/issues/275))
+  > ## Summary
+  > - use ratatui::run in the tui-bar-graph examples
+  > - keep CLI parsing, rendering behavior, and key handling unchanged
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-bar-graph --examples --all-features
+  > - cargo clippy -p tui-bar-graph --examples --all-features -- -D warnings
+
+- Modernize tui-big-text examples ([#276](https://github.com/ratatui/tui-widgets/issues/276))
+  > ## Summary
+  > - remove the shared big-text example terminal helper
+  > - use ratatui::run directly in the static examples
+  > - remove the custom Tui wrapper from the stopwatch example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+
+- Modernize tui-box-text example ([#277](https://github.com/ratatui/tui-widgets/issues/277))
+  > ## Summary
+  > - use ratatui::run in the tui-box-text example
+  > - handle key presses with as_key_press_event
+  > - allow both q and Esc to exit the example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-box-text --examples --all-features
+  > - cargo clippy -p tui-box-text --examples --all-features -- -D warnings
+
+- Modernize tui-cards example ([#278](https://github.com/ratatui/tui-widgets/issues/278))
+  > ## Summary
+  > - use ratatui::run in the tui-cards example
+  > - handle key presses with as_key_press_event and allow q or Esc to exit
+  > - remove the obsolete card background-fill workaround and stale README
+  > TODO
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-cards --examples --all-features
+  > - cargo clippy -p tui-cards --examples --all-features -- -D warnings
+  > - cargo rdme --check --manifest-path tui-cards/Cargo.toml
+
+- Modernize tui-popup examples ([#279](https://github.com/ratatui/tui-widgets/issues/279))
+  > ## Summary
+  > - use ratatui::run in the tui-popup examples
+  > - borrow DefaultTerminal in example run loops
+  > - handle key presses with as_key_press_event while preserving mouse
+  > handling in the state example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-popup --examples --all-features
+  > - cargo clippy -p tui-popup --examples --all-features -- -D warnings
+  > - just rdme-check
+
+- Install color-eyre in stopwatch example ([#280](https://github.com/ratatui/tui-widgets/issues/280))
+  > ## Summary
+  > - install color-eyre before running the tui-big-text stopwatch example
+  > - keep the stopwatch lifecycle and behavior unchanged
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+
+- Modernize tui-prompts examples ([#281](https://github.com/ratatui/tui-widgets/issues/281))
+  > ## Summary
+  > - use ratatui::run in the tui-prompts examples
+  > - remove the custom example Tui wrapper
+  > - install color-eyre before running the prompt examples
+  > - handle input with as_key_press_event while preserving prompt focus and
+  > submission behavior
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-prompts --examples --all-features
+  > - cargo clippy -p tui-prompts --examples --all-features -- -D warnings
+  > - cargo test -p tui-prompts --all-features
+
+- Modernize tui-qrcode example ([#282](https://github.com/ratatui/tui-widgets/issues/282))
+  > ## Summary
+  > - use ratatui::run in the tui-qrcode example
+  > - borrow DefaultTerminal in the run loop
+  > - handle key presses with as_key_press_event while preserving any-key
+  > exit behavior
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-qrcode --examples --all-features
+  > - cargo clippy -p tui-qrcode --examples --all-features -- -D warnings
+
+- Modernize tui-scrollbar examples ([#283](https://github.com/ratatui/tui-widgets/issues/283))
+  > ## Summary
+  > - use ratatui::run in the tui-scrollbar examples
+  > - borrow DefaultTerminal in example run loops
+  > - preserve mouse capture setup while using current key press helpers
+  > - add q/Esc exit consistency and vim motion keys for the mouse example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-scrollbar --examples --all-features
+  > - cargo clippy -p tui-scrollbar --examples --all-features -- -D warnings
+  > - just rdme-check
+
+- Modernize tui-scrollview examples ([#285](https://github.com/ratatui/tui-widgets/issues/285))
+  > ## Summary
+  > - use ratatui::run in the tui-scrollview examples
+  > - borrow DefaultTerminal in example run loops
+  > - use as_key_press_event for key handling
+  > - document each example's purpose and manual controls
+  > - add vertical controls to the horizontal scroll example, which has
+  > vertical overflow on normal terminals
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-scrollview --examples --all-features
+  > - cargo clippy -p tui-scrollview --examples --all-features -- -D
+  > warnings
+  > - just rdme-check
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.7.6] - 2026-06-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "tui-bar-graph"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "tui-big-text"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "tui-box-text"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "color-eyre",
  "indoc",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "tui-cards"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "color-eyre",
  "indoc",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "tui-equalizer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "tui-popup"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "tui-prompts"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "tui-qrcode"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "color-eyre",
  "qrcode",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "tui-scrollbar"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "color-eyre",
  "crossterm 0.28.1",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "tui-scrollview"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "color-eyre",
  "indoc",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "tui-widgets"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "document-features",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nursery = "warn"
 [package]
 name = "tui-widgets"
 description = "A collection of useful widgets for building terminal user interfaces using Ratatui"
-version = "0.7.6"
+version = "0.7.7"
 documentation = "https://docs.rs/tui-widgets"
 
 authors.workspace = true
@@ -96,13 +96,13 @@ scrollview = ["tui-scrollview"]
 [dependencies]
 document-features.workspace = true
 ratatui-core = { workspace = true }
-tui-bar-graph = { version = "0.3.3", path = "tui-bar-graph", optional = true }
-tui-big-text = { version = "0.8.5", path = "tui-big-text", optional = true }
-tui-box-text = { version = "0.3.3", path = "tui-box-text", optional = true }
-tui-cards = { version = "0.3.3", path = "tui-cards", optional = true }
-tui-equalizer = { version = "0.2.0", path = "tui-equalizer", optional = true }
-tui-popup = { version = "0.7.5", path = "tui-popup", optional = true }
-tui-prompts = { version = "0.6.4", path = "tui-prompts", optional = true }
-tui-qrcode = { version = "0.2.5", path = "tui-qrcode", optional = true }
-tui-scrollbar = { version = "0.2.6", path = "tui-scrollbar", optional = true }
-tui-scrollview = { version = "0.6.5", path = "tui-scrollview", optional = true }
+tui-bar-graph = { version = "0.3.4", path = "tui-bar-graph", optional = true }
+tui-big-text = { version = "0.8.6", path = "tui-big-text", optional = true }
+tui-box-text = { version = "0.3.4", path = "tui-box-text", optional = true }
+tui-cards = { version = "0.3.4", path = "tui-cards", optional = true }
+tui-equalizer = { version = "0.2.1", path = "tui-equalizer", optional = true }
+tui-popup = { version = "0.7.6", path = "tui-popup", optional = true }
+tui-prompts = { version = "0.6.5", path = "tui-prompts", optional = true }
+tui-qrcode = { version = "0.2.6", path = "tui-qrcode", optional = true }
+tui-scrollbar = { version = "0.2.7", path = "tui-scrollbar", optional = true }
+tui-scrollview = { version = "0.6.6", path = "tui-scrollview", optional = true }

--- a/tui-bar-graph/CHANGELOG.md
+++ b/tui-bar-graph/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-bar-graph examples ([#275](https://github.com/ratatui/tui-widgets/issues/275))
+  > ## Summary
+  > - use ratatui::run in the tui-bar-graph examples
+  > - keep CLI parsing, rendering behavior, and key handling unchanged
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-bar-graph --examples --all-features
+  > - cargo clippy -p tui-bar-graph --examples --all-features -- -D warnings
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.3.3] - 2026-04-04
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-bar-graph/Cargo.toml
+++ b/tui-bar-graph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-bar-graph"
 description = "A Ratatui widget for rendering pretty bar graphs in the terminal"
-version = "0.3.3"
+version = "0.3.4"
 documentation = "https://docs.rs/tui-bar-graph"
 authors.workspace = true
 license.workspace = true

--- a/tui-big-text/CHANGELOG.md
+++ b/tui-big-text/CHANGELOG.md
@@ -2,6 +2,87 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.6] - 2026-06-14
+
+### 🐛 Bug Fixes
+
+- Ignore non-press key events in examples ([#284](https://github.com/ratatui/tui-widgets/issues/284))
+  > ## Summary
+  > - ignore release and repeat key events in the tui-big-text stopwatch
+  > example
+  > - confirm the remaining examples already filter key handling to press
+  > events
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+  > - just rdme-check
+
+### 📚 Documentation
+
+- Modernize tui-big-text examples ([#276](https://github.com/ratatui/tui-widgets/issues/276))
+  > ## Summary
+  > - remove the shared big-text example terminal helper
+  > - use ratatui::run directly in the static examples
+  > - remove the custom Tui wrapper from the stopwatch example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+
+- Install color-eyre in stopwatch example ([#280](https://github.com/ratatui/tui-widgets/issues/280))
+  > ## Summary
+  > - install color-eyre before running the tui-big-text stopwatch example
+  > - keep the stopwatch lifecycle and behavior unchanged
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-big-text --examples --all-features
+  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.8.5] - 2026-06-11
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-big-text/Cargo.toml
+++ b/tui-big-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-big-text"
-version = "0.8.5"
+version = "0.8.6"
 description = "A Ratatui widget for displaying big text in the terminal"
 documentation = "https://docs.rs/tui-big-text"
 

--- a/tui-box-text/CHANGELOG.md
+++ b/tui-box-text/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-box-text example ([#277](https://github.com/ratatui/tui-widgets/issues/277))
+  > ## Summary
+  > - use ratatui::run in the tui-box-text example
+  > - handle key presses with as_key_press_event
+  > - allow both q and Esc to exit the example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-box-text --examples --all-features
+  > - cargo clippy -p tui-box-text --examples --all-features -- -D warnings
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.3.3] - 2026-04-04
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-box-text/Cargo.toml
+++ b/tui-box-text/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-box-text"
 description = "A Ratatui widget for displaying text using the box drawing characters"
-version = "0.3.3"
+version = "0.3.4"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/tui-cards/CHANGELOG.md
+++ b/tui-cards/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-cards example ([#278](https://github.com/ratatui/tui-widgets/issues/278))
+  > ## Summary
+  > - use ratatui::run in the tui-cards example
+  > - handle key presses with as_key_press_event and allow q or Esc to exit
+  > - remove the obsolete card background-fill workaround and stale README
+  > TODO
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-cards --examples --all-features
+  > - cargo clippy -p tui-cards --examples --all-features -- -D warnings
+  > - cargo rdme --check --manifest-path tui-cards/Cargo.toml
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.3.3] - 2026-04-04
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-cards/Cargo.toml
+++ b/tui-cards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-cards"
-version = "0.3.3"
+version = "0.3.4"
 description = "A playing card widget for Ratatui"
 documentation = "https://docs.rs/tui-cards"
 

--- a/tui-equalizer/CHANGELOG.md
+++ b/tui-equalizer/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.1] - 2026-06-14
+
+### 📚 Documentation
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+

--- a/tui-equalizer/Cargo.toml
+++ b/tui-equalizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-equalizer"
 description = "An equalizer widget for Ratatui with multiple frequency bands."
-version = "0.2.0"
+version = "0.2.1"
 documentation = "https://docs.rs/tui-equalizer"
 
 authors.workspace = true

--- a/tui-popup/CHANGELOG.md
+++ b/tui-popup/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.6] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-popup examples ([#279](https://github.com/ratatui/tui-widgets/issues/279))
+  > ## Summary
+  > - use ratatui::run in the tui-popup examples
+  > - borrow DefaultTerminal in example run loops
+  > - handle key presses with as_key_press_event while preserving mouse
+  > handling in the state example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-popup --examples --all-features
+  > - cargo clippy -p tui-popup --examples --all-features -- -D warnings
+  > - just rdme-check
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.7.5] - 2026-06-11
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-popup/Cargo.toml
+++ b/tui-popup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-popup"
-version = "0.7.5"
+version = "0.7.6"
 description = "A simple popup for ratatui"
 documentation = "https://docs.rs/tui-popup"
 

--- a/tui-prompts/CHANGELOG.md
+++ b/tui-prompts/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.5] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-prompts examples ([#281](https://github.com/ratatui/tui-widgets/issues/281))
+  > ## Summary
+  > - use ratatui::run in the tui-prompts examples
+  > - remove the custom example Tui wrapper
+  > - install color-eyre before running the prompt examples
+  > - handle input with as_key_press_event while preserving prompt focus and
+  > submission behavior
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-prompts --examples --all-features
+  > - cargo clippy -p tui-prompts --examples --all-features -- -D warnings
+  > - cargo test -p tui-prompts --all-features
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.6.4] - 2026-06-11
 
 ### 🚀 Features

--- a/tui-prompts/Cargo.toml
+++ b/tui-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-prompts"
-version = "0.6.4"
+version = "0.6.5"
 description = "A library for building interactive prompts for ratatui."
 
 authors.workspace = true

--- a/tui-qrcode/CHANGELOG.md
+++ b/tui-qrcode/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.6] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-qrcode example ([#282](https://github.com/ratatui/tui-widgets/issues/282))
+  > ## Summary
+  > - use ratatui::run in the tui-qrcode example
+  > - borrow DefaultTerminal in the run loop
+  > - handle key presses with as_key_press_event while preserving any-key
+  > exit behavior
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-qrcode --examples --all-features
+  > - cargo clippy -p tui-qrcode --examples --all-features -- -D warnings
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.2.5] - 2026-06-11
 
 ### ⚙️ Miscellaneous Tasks

--- a/tui-qrcode/Cargo.toml
+++ b/tui-qrcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-qrcode"
-version = "0.2.5"
+version = "0.2.6"
 description = "A Ratatui widget for displaying QR codes in the terminal"
 documentation = "https://docs.rs/tui-qrcode"
 

--- a/tui-scrollbar/CHANGELOG.md
+++ b/tui-scrollbar/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.7] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-scrollbar examples ([#283](https://github.com/ratatui/tui-widgets/issues/283))
+  > ## Summary
+  > - use ratatui::run in the tui-scrollbar examples
+  > - borrow DefaultTerminal in example run loops
+  > - preserve mouse capture setup while using current key press helpers
+  > - add q/Esc exit consistency and vim motion keys for the mouse example
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-scrollbar --examples --all-features
+  > - cargo clippy -p tui-scrollbar --examples --all-features -- -D warnings
+  > - just rdme-check
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.2.6] - 2026-06-11
 
 ### 📚 Documentation

--- a/tui-scrollbar/Cargo.toml
+++ b/tui-scrollbar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-scrollbar"
-version = "0.2.6"
+version = "0.2.7"
 description = "A Ratatui scrollbar widget with fractional thumb rendering"
 documentation = "https://docs.rs/tui-scrollbar"
 

--- a/tui-scrollview/CHANGELOG.md
+++ b/tui-scrollview/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.6] - 2026-06-14
+
+### 📚 Documentation
+
+- Modernize tui-scrollview examples ([#285](https://github.com/ratatui/tui-widgets/issues/285))
+  > ## Summary
+  > - use ratatui::run in the tui-scrollview examples
+  > - borrow DefaultTerminal in example run loops
+  > - use as_key_press_event for key handling
+  > - document each example's purpose and manual controls
+  > - add vertical controls to the horizontal scroll example, which has
+  > vertical overflow on normal terminals
+  >
+  > ## Validation
+  > - cargo +nightly fmt --all
+  > - cargo check -p tui-scrollview --examples --all-features
+  > - cargo clippy -p tui-scrollview --examples --all-features -- -D
+  > warnings
+  > - just rdme-check
+
+- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
+  > ## Summary
+  >
+  > - add run commands and widget-specific context to the example module
+  > docs
+  > - add targeted inline comments for non-obvious example sizing, state,
+  > and rendering choices
+  > - fix broken crate-root `Ratatui` reference links that surfaced during
+  > docs validation
+  >
+  > ## Validation
+  >
+  > - `cargo +nightly fmt --all --check`
+  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
+  > - `cargo doc --workspace --examples --all-features --no-deps`
+  >
+  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
+  > output filename collision.
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
+  > ## Summary
+  > - migrate the workspace package edition from Rust 2021 to Rust 2024
+  > - apply Cargo edition fixes for lifetime capture and macro fragment
+  > specifiers
+  > - apply mechanical Clippy let-chain fixes needed for the stable -D
+  > warnings gate
+  > - refresh generated README snippets and document the pre-push README
+  > check in AGENTS.md
+  >
+  > ## Validation
+  > - cargo fix --edition --all-features --workspace --allow-dirty
+  > --allow-staged
+  > - just fmt
+  > - just clippy-stable
+  > - cargo test --all-features --workspace
+  > - just rdme-check
+  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
+
+
 ## [0.6.5] - 2026-06-11
 
 ### 🚀 Features

--- a/tui-scrollview/Cargo.toml
+++ b/tui-scrollview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-scrollview"
-version = "0.6.5"
+version = "0.6.6"
 description = "A simple scrollable view for Ratatui"
 
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `tui-bar-graph`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `tui-big-text`: 0.8.5 -> 0.8.6 (✓ API compatible changes)
* `tui-box-text`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `tui-cards`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `tui-equalizer`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `tui-popup`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `tui-prompts`: 0.6.4 -> 0.6.5 (✓ API compatible changes)
* `tui-qrcode`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `tui-scrollbar`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `tui-scrollview`: 0.6.5 -> 0.6.6 (✓ API compatible changes)
* `tui-widgets`: 0.7.6 -> 0.7.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `tui-bar-graph`

<blockquote>

## [0.3.4] - 2026-06-14

### 📚 Documentation

- Modernize tui-bar-graph examples ([#275](https://github.com/ratatui/tui-widgets/issues/275))
  > ## Summary
  > - use ratatui::run in the tui-bar-graph examples
  > - keep CLI parsing, rendering behavior, and key handling unchanged
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-bar-graph --examples --all-features
  > - cargo clippy -p tui-bar-graph --examples --all-features -- -D warnings

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-big-text`

<blockquote>

## [0.8.6] - 2026-06-14

### 🐛 Bug Fixes

- Ignore non-press key events in examples ([#284](https://github.com/ratatui/tui-widgets/issues/284))
  > ## Summary
  > - ignore release and repeat key events in the tui-big-text stopwatch
  > example
  > - confirm the remaining examples already filter key handling to press
  > events
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
  > - just rdme-check

### 📚 Documentation

- Modernize tui-big-text examples ([#276](https://github.com/ratatui/tui-widgets/issues/276))
  > ## Summary
  > - remove the shared big-text example terminal helper
  > - use ratatui::run directly in the static examples
  > - remove the custom Tui wrapper from the stopwatch example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings

- Install color-eyre in stopwatch example ([#280](https://github.com/ratatui/tui-widgets/issues/280))
  > ## Summary
  > - install color-eyre before running the tui-big-text stopwatch example
  > - keep the stopwatch lifecycle and behavior unchanged
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-box-text`

<blockquote>

## [0.3.4] - 2026-06-14

### 📚 Documentation

- Modernize tui-box-text example ([#277](https://github.com/ratatui/tui-widgets/issues/277))
  > ## Summary
  > - use ratatui::run in the tui-box-text example
  > - handle key presses with as_key_press_event
  > - allow both q and Esc to exit the example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-box-text --examples --all-features
  > - cargo clippy -p tui-box-text --examples --all-features -- -D warnings

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-cards`

<blockquote>

## [0.3.4] - 2026-06-14

### 📚 Documentation

- Modernize tui-cards example ([#278](https://github.com/ratatui/tui-widgets/issues/278))
  > ## Summary
  > - use ratatui::run in the tui-cards example
  > - handle key presses with as_key_press_event and allow q or Esc to exit
  > - remove the obsolete card background-fill workaround and stale README
  > TODO
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-cards --examples --all-features
  > - cargo clippy -p tui-cards --examples --all-features -- -D warnings
  > - cargo rdme --check --manifest-path tui-cards/Cargo.toml

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-equalizer`

<blockquote>

## [0.2.1] - 2026-06-14

### 📚 Documentation

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-popup`

<blockquote>

## [0.7.6] - 2026-06-14

### 📚 Documentation

- Modernize tui-popup examples ([#279](https://github.com/ratatui/tui-widgets/issues/279))
  > ## Summary
  > - use ratatui::run in the tui-popup examples
  > - borrow DefaultTerminal in example run loops
  > - handle key presses with as_key_press_event while preserving mouse
  > handling in the state example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-popup --examples --all-features
  > - cargo clippy -p tui-popup --examples --all-features -- -D warnings
  > - just rdme-check

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-prompts`

<blockquote>

## [0.6.5] - 2026-06-14

### 📚 Documentation

- Modernize tui-prompts examples ([#281](https://github.com/ratatui/tui-widgets/issues/281))
  > ## Summary
  > - use ratatui::run in the tui-prompts examples
  > - remove the custom example Tui wrapper
  > - install color-eyre before running the prompt examples
  > - handle input with as_key_press_event while preserving prompt focus and
  > submission behavior
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-prompts --examples --all-features
  > - cargo clippy -p tui-prompts --examples --all-features -- -D warnings
  > - cargo test -p tui-prompts --all-features

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-qrcode`

<blockquote>

## [0.2.6] - 2026-06-14

### 📚 Documentation

- Modernize tui-qrcode example ([#282](https://github.com/ratatui/tui-widgets/issues/282))
  > ## Summary
  > - use ratatui::run in the tui-qrcode example
  > - borrow DefaultTerminal in the run loop
  > - handle key presses with as_key_press_event while preserving any-key
  > exit behavior
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-qrcode --examples --all-features
  > - cargo clippy -p tui-qrcode --examples --all-features -- -D warnings

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-scrollbar`

<blockquote>

## [0.2.7] - 2026-06-14

### 📚 Documentation

- Modernize tui-scrollbar examples ([#283](https://github.com/ratatui/tui-widgets/issues/283))
  > ## Summary
  > - use ratatui::run in the tui-scrollbar examples
  > - borrow DefaultTerminal in example run loops
  > - preserve mouse capture setup while using current key press helpers
  > - add q/Esc exit consistency and vim motion keys for the mouse example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-scrollbar --examples --all-features
  > - cargo clippy -p tui-scrollbar --examples --all-features -- -D warnings
  > - just rdme-check

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-scrollview`

<blockquote>

## [0.6.6] - 2026-06-14

### 📚 Documentation

- Modernize tui-scrollview examples ([#285](https://github.com/ratatui/tui-widgets/issues/285))
  > ## Summary
  > - use ratatui::run in the tui-scrollview examples
  > - borrow DefaultTerminal in example run loops
  > - use as_key_press_event for key handling
  > - document each example's purpose and manual controls
  > - add vertical controls to the horizontal scroll example, which has
  > vertical overflow on normal terminals
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-scrollview --examples --all-features
  > - cargo clippy -p tui-scrollview --examples --all-features -- -D
  > warnings
  > - just rdme-check

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>

## `tui-widgets`

<blockquote>

## [0.7.7] - 2026-06-14

### 🐛 Bug Fixes

- Ignore non-press key events in examples ([#284](https://github.com/ratatui/tui-widgets/issues/284))
  > ## Summary
  > - ignore release and repeat key events in the tui-big-text stopwatch
  > example
  > - confirm the remaining examples already filter key handling to press
  > events
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings
  > - just rdme-check

### 📚 Documentation

- Modernize tui-bar-graph examples ([#275](https://github.com/ratatui/tui-widgets/issues/275))
  > ## Summary
  > - use ratatui::run in the tui-bar-graph examples
  > - keep CLI parsing, rendering behavior, and key handling unchanged
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-bar-graph --examples --all-features
  > - cargo clippy -p tui-bar-graph --examples --all-features -- -D warnings

- Modernize tui-big-text examples ([#276](https://github.com/ratatui/tui-widgets/issues/276))
  > ## Summary
  > - remove the shared big-text example terminal helper
  > - use ratatui::run directly in the static examples
  > - remove the custom Tui wrapper from the stopwatch example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings

- Modernize tui-box-text example ([#277](https://github.com/ratatui/tui-widgets/issues/277))
  > ## Summary
  > - use ratatui::run in the tui-box-text example
  > - handle key presses with as_key_press_event
  > - allow both q and Esc to exit the example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-box-text --examples --all-features
  > - cargo clippy -p tui-box-text --examples --all-features -- -D warnings

- Modernize tui-cards example ([#278](https://github.com/ratatui/tui-widgets/issues/278))
  > ## Summary
  > - use ratatui::run in the tui-cards example
  > - handle key presses with as_key_press_event and allow q or Esc to exit
  > - remove the obsolete card background-fill workaround and stale README
  > TODO
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-cards --examples --all-features
  > - cargo clippy -p tui-cards --examples --all-features -- -D warnings
  > - cargo rdme --check --manifest-path tui-cards/Cargo.toml

- Modernize tui-popup examples ([#279](https://github.com/ratatui/tui-widgets/issues/279))
  > ## Summary
  > - use ratatui::run in the tui-popup examples
  > - borrow DefaultTerminal in example run loops
  > - handle key presses with as_key_press_event while preserving mouse
  > handling in the state example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-popup --examples --all-features
  > - cargo clippy -p tui-popup --examples --all-features -- -D warnings
  > - just rdme-check

- Install color-eyre in stopwatch example ([#280](https://github.com/ratatui/tui-widgets/issues/280))
  > ## Summary
  > - install color-eyre before running the tui-big-text stopwatch example
  > - keep the stopwatch lifecycle and behavior unchanged
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-big-text --examples --all-features
  > - cargo clippy -p tui-big-text --examples --all-features -- -D warnings

- Modernize tui-prompts examples ([#281](https://github.com/ratatui/tui-widgets/issues/281))
  > ## Summary
  > - use ratatui::run in the tui-prompts examples
  > - remove the custom example Tui wrapper
  > - install color-eyre before running the prompt examples
  > - handle input with as_key_press_event while preserving prompt focus and
  > submission behavior
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-prompts --examples --all-features
  > - cargo clippy -p tui-prompts --examples --all-features -- -D warnings
  > - cargo test -p tui-prompts --all-features

- Modernize tui-qrcode example ([#282](https://github.com/ratatui/tui-widgets/issues/282))
  > ## Summary
  > - use ratatui::run in the tui-qrcode example
  > - borrow DefaultTerminal in the run loop
  > - handle key presses with as_key_press_event while preserving any-key
  > exit behavior
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-qrcode --examples --all-features
  > - cargo clippy -p tui-qrcode --examples --all-features -- -D warnings

- Modernize tui-scrollbar examples ([#283](https://github.com/ratatui/tui-widgets/issues/283))
  > ## Summary
  > - use ratatui::run in the tui-scrollbar examples
  > - borrow DefaultTerminal in example run loops
  > - preserve mouse capture setup while using current key press helpers
  > - add q/Esc exit consistency and vim motion keys for the mouse example
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-scrollbar --examples --all-features
  > - cargo clippy -p tui-scrollbar --examples --all-features -- -D warnings
  > - just rdme-check

- Modernize tui-scrollview examples ([#285](https://github.com/ratatui/tui-widgets/issues/285))
  > ## Summary
  > - use ratatui::run in the tui-scrollview examples
  > - borrow DefaultTerminal in example run loops
  > - use as_key_press_event for key handling
  > - document each example's purpose and manual controls
  > - add vertical controls to the horizontal scroll example, which has
  > vertical overflow on normal terminals
  >
  > ## Validation
  > - cargo +nightly fmt --all
  > - cargo check -p tui-scrollview --examples --all-features
  > - cargo clippy -p tui-scrollview --examples --all-features -- -D
  > warnings
  > - just rdme-check

- Document widget examples ([#286](https://github.com/ratatui/tui-widgets/issues/286))
  > ## Summary
  >
  > - add run commands and widget-specific context to the example module
  > docs
  > - add targeted inline comments for non-obvious example sizing, state,
  > and rendering choices
  > - fix broken crate-root `Ratatui` reference links that surfaced during
  > docs validation
  >
  > ## Validation
  >
  > - `cargo +nightly fmt --all --check`
  > - `cargo clippy --workspace --examples --all-features -- -D warnings`
  > - `cargo doc --workspace --examples --all-features --no-deps`
  >
  > `cargo doc` still reports the existing `tui-bar-graph` example/lib
  > output filename collision.

### ⚙️ Miscellaneous Tasks

- Migrate workspace to Rust 2024 ([#263](https://github.com/ratatui/tui-widgets/issues/263))
  > ## Summary
  > - migrate the workspace package edition from Rust 2021 to Rust 2024
  > - apply Cargo edition fixes for lifetime capture and macro fragment
  > specifiers
  > - apply mechanical Clippy let-chain fixes needed for the stable -D
  > warnings gate
  > - refresh generated README snippets and document the pre-push README
  > check in AGENTS.md
  >
  > ## Validation
  > - cargo fix --edition --all-features --workspace --allow-dirty
  > --allow-staged
  > - just fmt
  > - just clippy-stable
  > - cargo test --all-features --workspace
  > - just rdme-check
  > - markdownlint-cli2 AGENTS.md README.md tui-*/README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).