### PR TITLE
feat(scrollview): render by reference

### DIFF
--- a/tui-scrollview/README.md
+++ b/tui-scrollview/README.md
@@ -60,6 +60,30 @@ impl StatefulWidget for MyScrollableWidget {
 }
 ```
 
+Store the `ScrollView` if its content is expensive to rebuild or changes independently from the
+frame render. A stored scroll view can be rendered by reference while `ScrollViewState` keeps
+the current offset.
+
+```rust
+use ratatui::prelude::*;
+use tui_scrollview::{ScrollView, ScrollViewState};
+
+struct App {
+    scroll_view: ScrollView,
+    scroll_view_state: ScrollViewState,
+}
+
+impl App {
+    fn draw(&mut self, frame: &mut Frame) {
+        frame.render_stateful_widget(
+            &self.scroll_view,
+            frame.area(),
+            &mut self.scroll_view_state,
+        );
+    }
+}
+```
+
 ## Full Example
 
 A full example can be found in the [examples directory].

--- a/tui-scrollview/src/lib.rs
+++ b/tui-scrollview/src/lib.rs
@@ -56,6 +56,30 @@
 //! }
 //! ```
 //!
+//! Store the `ScrollView` if its content is expensive to rebuild or changes independently from the
+//! frame render. A stored scroll view can be rendered by reference while `ScrollViewState` keeps
+//! the current offset.
+//!
+//! ```rust
+//! use ratatui::prelude::*;
+//! use tui_scrollview::{ScrollView, ScrollViewState};
+//!
+//! struct App {
+//!     scroll_view: ScrollView,
+//!     scroll_view_state: ScrollViewState,
+//! }
+//!
+//! impl App {
+//!     fn draw(&mut self, frame: &mut Frame) {
+//!         frame.render_stateful_widget(
+//!             &self.scroll_view,
+//!             frame.area(),
+//!             &mut self.scroll_view_state,
+//!         );
+//!     }
+//! }
+//! ```
+//!
 //! # Full Example
 //!
 //! A full example can be found in the [examples directory].

--- a/tui-scrollview/src/scroll_view.rs
+++ b/tui-scrollview/src/scroll_view.rs
@@ -47,6 +47,18 @@ use crate::ScrollViewState;
 /// frame.render_stateful_widget(scroll_view, frame.size(), state);
 /// # }
 /// ```
+///
+/// If you store the `ScrollView`, render it by reference so the same prepared buffer can be reused
+/// across frames.
+///
+/// ```rust
+/// use ratatui::prelude::*;
+/// use tui_scrollview::{ScrollView, ScrollViewState};
+///
+/// # fn terminal_draw(frame: &mut Frame, scroll_view: &ScrollView, state: &mut ScrollViewState) {
+/// frame.render_stateful_widget(scroll_view, frame.area(), state);
+/// # }
+/// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct ScrollView {
     buf: Buffer,
@@ -209,6 +221,14 @@ impl ScrollView {
 }
 
 impl StatefulWidget for ScrollView {
+    type State = ScrollViewState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        (&self).render(area, buf, state);
+    }
+}
+
+impl StatefulWidget for &ScrollView {
     type State = ScrollViewState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
@@ -428,6 +448,22 @@ mod tests {
                 "◄██═► ",
             ])
         )
+    }
+
+    #[rstest]
+    fn render_by_reference_matches_owned_render(scroll_view: ScrollView) {
+        let mut owned_state = ScrollViewState::default();
+        let mut borrowed_state = ScrollViewState::default();
+        let mut owned_buf = Buffer::empty(Rect::new(0, 0, 6, 6));
+        let mut borrowed_buf = Buffer::empty(Rect::new(0, 0, 6, 6));
+
+        scroll_view
+            .clone()
+            .render(owned_buf.area, &mut owned_buf, &mut owned_state);
+        (&scroll_view).render(borrowed_buf.area, &mut borrowed_buf, &mut borrowed_state);
+
+        assert_eq!(borrowed_buf, owned_buf);
+        assert_eq!(borrowed_state, owned_state);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- add `StatefulWidget for &ScrollView`
- keep the owned `StatefulWidget for ScrollView` path as a compatibility shim
- document the stored scroll view pattern and regenerate the README

## Validation

- `cargo test -p tui-scrollview --all-features`
- `cargo clippy -p tui-scrollview --all-targets --all-features -- -D warnings`
- `cargo rdme --check --manifest-path tui-scrollview/Cargo.toml`
- `markdownlint-cli2 tui-scrollview/README.md`