### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.8] - 2026-06-14
+
+### 🚀 Features
+
+- *(big-text)* Render by reference ([#288](https://github.com/ratatui/tui-widgets/issues/288))
+  > ## Summary
+  >
+  > - add `Widget for &BigText`
+  > - keep the owned `Widget for BigText` path as a compatibility shim
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+- *(equalizer)* Render by reference ([#290](https://github.com/ratatui/tui-widgets/issues/290))
+  > ## Summary
+  >
+  > - add `Widget for &Equalizer`
+  > - make band rendering borrow each band instead of consuming it
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+- *(bar-graph)* Render by reference ([#289](https://github.com/ratatui/tui-widgets/issues/289))
+  > ## Summary
+  >
+  > - add `Widget for &BarGraph`
+  > - keep the owned `Widget for BarGraph` path as a compatibility shim
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+- *(prompts)* Render text prompts by reference ([#291](https://github.com/ratatui/tui-widgets/issues/291))
+  > ## Summary
+  >
+  > - add `StatefulWidget for &TextPrompt`
+  > - add `Prompt for &TextPrompt` so stored prompt configuration can be
+  > drawn by reference
+  > - document the stored prompt pattern and regenerate the README
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-prompts --all-features`
+  > - `cargo clippy -p tui-prompts --all-targets --all-features -- -D
+  > warnings`
+  > - `cargo rdme --check --manifest-path tui-prompts/Cargo.toml`
+  > - `markdownlint-cli2 tui-prompts/README.md`
+
+- *(scrollview)* Render by reference ([#292](https://github.com/ratatui/tui-widgets/issues/292))
+  > ## Summary
+  >
+  > - add `StatefulWidget for &ScrollView`
+  > - keep the owned `StatefulWidget for ScrollView` path as a compatibility
+  > shim
+  > - document the stored scroll view pattern and regenerate the README
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+  > - `cargo rdme --check --manifest-path tui-scrollview/Cargo.toml`
+  > - `markdownlint-cli2 tui-scrollview/README.md`
+
+
 ## [0.7.7] - 2026-06-14
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "tui-bar-graph"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "tui-big-text"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "tui-equalizer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "tui-prompts"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "tui-scrollview"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "color-eyre",
  "indoc",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "tui-widgets"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "document-features",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nursery = "warn"
 [package]
 name = "tui-widgets"
 description = "A collection of useful widgets for building terminal user interfaces using Ratatui"
-version = "0.7.7"
+version = "0.7.8"
 documentation = "https://docs.rs/tui-widgets"
 
 authors.workspace = true
@@ -96,13 +96,13 @@ scrollview = ["tui-scrollview"]
 [dependencies]
 document-features.workspace = true
 ratatui-core = { workspace = true }
-tui-bar-graph = { version = "0.3.4", path = "tui-bar-graph", optional = true }
-tui-big-text = { version = "0.8.6", path = "tui-big-text", optional = true }
+tui-bar-graph = { version = "0.3.5", path = "tui-bar-graph", optional = true }
+tui-big-text = { version = "0.8.7", path = "tui-big-text", optional = true }
 tui-box-text = { version = "0.3.4", path = "tui-box-text", optional = true }
 tui-cards = { version = "0.3.4", path = "tui-cards", optional = true }
-tui-equalizer = { version = "0.2.1", path = "tui-equalizer", optional = true }
+tui-equalizer = { version = "0.2.2", path = "tui-equalizer", optional = true }
 tui-popup = { version = "0.7.6", path = "tui-popup", optional = true }
-tui-prompts = { version = "0.6.5", path = "tui-prompts", optional = true }
+tui-prompts = { version = "0.6.6", path = "tui-prompts", optional = true }
 tui-qrcode = { version = "0.2.6", path = "tui-qrcode", optional = true }
 tui-scrollbar = { version = "0.2.7", path = "tui-scrollbar", optional = true }
-tui-scrollview = { version = "0.6.6", path = "tui-scrollview", optional = true }
+tui-scrollview = { version = "0.6.7", path = "tui-scrollview", optional = true }

--- a/tui-bar-graph/CHANGELOG.md
+++ b/tui-bar-graph/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5] - 2026-06-14
+
+### 🚀 Features
+
+- *(bar-graph)* Render by reference ([#289](https://github.com/ratatui/tui-widgets/issues/289))
+  > ## Summary
+  >
+  > - add `Widget for &BarGraph`
+  > - keep the owned `Widget for BarGraph` path as a compatibility shim
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+
 ## [0.3.4] - 2026-06-14
 
 ### 📚 Documentation

--- a/tui-bar-graph/Cargo.toml
+++ b/tui-bar-graph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-bar-graph"
 description = "A Ratatui widget for rendering pretty bar graphs in the terminal"
-version = "0.3.4"
+version = "0.3.5"
 documentation = "https://docs.rs/tui-bar-graph"
 authors.workspace = true
 license.workspace = true

--- a/tui-big-text/CHANGELOG.md
+++ b/tui-big-text/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.7] - 2026-06-14
+
+### 🚀 Features
+
+- *(big-text)* Render by reference ([#288](https://github.com/ratatui/tui-widgets/issues/288))
+  > ## Summary
+  >
+  > - add `Widget for &BigText`
+  > - keep the owned `Widget for BigText` path as a compatibility shim
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+
 ## [0.8.6] - 2026-06-14
 
 ### 🐛 Bug Fixes

--- a/tui-big-text/Cargo.toml
+++ b/tui-big-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-big-text"
-version = "0.8.6"
+version = "0.8.7"
 description = "A Ratatui widget for displaying big text in the terminal"
 documentation = "https://docs.rs/tui-big-text"
 

--- a/tui-equalizer/CHANGELOG.md
+++ b/tui-equalizer/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2026-06-14
+
+### 🚀 Features
+
+- *(equalizer)* Render by reference ([#290](https://github.com/ratatui/tui-widgets/issues/290))
+  > ## Summary
+  >
+  > - add `Widget for &Equalizer`
+  > - make band rendering borrow each band instead of consuming it
+  > - cover borrowed rendering against owned rendering
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
+  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+
+
 ## [0.2.1] - 2026-06-14
 
 ### 📚 Documentation

--- a/tui-equalizer/Cargo.toml
+++ b/tui-equalizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-equalizer"
 description = "An equalizer widget for Ratatui with multiple frequency bands."
-version = "0.2.1"
+version = "0.2.2"
 documentation = "https://docs.rs/tui-equalizer"
 
 authors.workspace = true

--- a/tui-prompts/CHANGELOG.md
+++ b/tui-prompts/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.6] - 2026-06-14
+
+### 🚀 Features
+
+- *(prompts)* Render text prompts by reference ([#291](https://github.com/ratatui/tui-widgets/issues/291))
+  > ## Summary
+  >
+  > - add `StatefulWidget for &TextPrompt`
+  > - add `Prompt for &TextPrompt` so stored prompt configuration can be
+  > drawn by reference
+  > - document the stored prompt pattern and regenerate the README
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-prompts --all-features`
+  > - `cargo clippy -p tui-prompts --all-targets --all-features -- -D
+  > warnings`
+  > - `cargo rdme --check --manifest-path tui-prompts/Cargo.toml`
+  > - `markdownlint-cli2 tui-prompts/README.md`
+
+
 ## [0.6.5] - 2026-06-14
 
 ### 📚 Documentation

--- a/tui-prompts/Cargo.toml
+++ b/tui-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-prompts"
-version = "0.6.5"
+version = "0.6.6"
 description = "A library for building interactive prompts for ratatui."
 
 authors.workspace = true

--- a/tui-scrollview/CHANGELOG.md
+++ b/tui-scrollview/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.7] - 2026-06-14
+
+### 🚀 Features
+
+- *(scrollview)* Render by reference ([#292](https://github.com/ratatui/tui-widgets/issues/292))
+  > ## Summary
+  >
+  > - add `StatefulWidget for &ScrollView`
+  > - keep the owned `StatefulWidget for ScrollView` path as a compatibility
+  > shim
+  > - document the stored scroll view pattern and regenerate the README
+  >
+  > ## Validation
+  >
+  > - `cargo test -p tui-scrollview --all-features`
+  > - `cargo clippy -p tui-scrollview --all-targets --all-features -- -D
+  > warnings`
+  > - `cargo rdme --check --manifest-path tui-scrollview/Cargo.toml`
+  > - `markdownlint-cli2 tui-scrollview/README.md`
+
+
 ## [0.6.6] - 2026-06-14
 
 ### 📚 Documentation

--- a/tui-scrollview/Cargo.toml
+++ b/tui-scrollview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-scrollview"
-version = "0.6.6"
+version = "0.6.7"
 description = "A simple scrollable view for Ratatui"
 
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `tui-bar-graph`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `tui-big-text`: 0.8.6 -> 0.8.7 (✓ API compatible changes)
* `tui-equalizer`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `tui-prompts`: 0.6.5 -> 0.6.6 (✓ API compatible changes)
* `tui-scrollview`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `tui-widgets`: 0.7.7 -> 0.7.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `tui-bar-graph`

<blockquote>

## [0.3.5] - 2026-06-14

### 🚀 Features

- *(bar-graph)* Render by reference ([#289](https://github.com/ratatui/tui-widgets/issues/289))
  > ## Summary
  >
  > - add `Widget for &BarGraph`
  > - keep the owned `Widget for BarGraph` path as a compatibility shim
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`
</blockquote>

## `tui-big-text`

<blockquote>

## [0.8.7] - 2026-06-14

### 🚀 Features

- *(big-text)* Render by reference ([#288](https://github.com/ratatui/tui-widgets/issues/288))
  > ## Summary
  >
  > - add `Widget for &BigText`
  > - keep the owned `Widget for BigText` path as a compatibility shim
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`
</blockquote>

## `tui-equalizer`

<blockquote>

## [0.2.2] - 2026-06-14

### 🚀 Features

- *(equalizer)* Render by reference ([#290](https://github.com/ratatui/tui-widgets/issues/290))
  > ## Summary
  >
  > - add `Widget for &Equalizer`
  > - make band rendering borrow each band instead of consuming it
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`
</blockquote>

## `tui-prompts`

<blockquote>

## [0.6.6] - 2026-06-14

### 🚀 Features

- *(prompts)* Render text prompts by reference ([#291](https://github.com/ratatui/tui-widgets/issues/291))
  > ## Summary
  >
  > - add `StatefulWidget for &TextPrompt`
  > - add `Prompt for &TextPrompt` so stored prompt configuration can be
  > drawn by reference
  > - document the stored prompt pattern and regenerate the README
  >
  > ## Validation
  >
  > - `cargo test -p tui-prompts --all-features`
  > - `cargo clippy -p tui-prompts --all-targets --all-features -- -D
  > warnings`
  > - `cargo rdme --check --manifest-path tui-prompts/Cargo.toml`
  > - `markdownlint-cli2 tui-prompts/README.md`
</blockquote>

## `tui-scrollview`

<blockquote>

## [0.6.7] - 2026-06-14

### 🚀 Features

- *(scrollview)* Render by reference ([#292](https://github.com/ratatui/tui-widgets/issues/292))
  > ## Summary
  >
  > - add `StatefulWidget for &ScrollView`
  > - keep the owned `StatefulWidget for ScrollView` path as a compatibility
  > shim
  > - document the stored scroll view pattern and regenerate the README
  >
  > ## Validation
  >
  > - `cargo test -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-scrollview --all-targets --all-features -- -D
  > warnings`
  > - `cargo rdme --check --manifest-path tui-scrollview/Cargo.toml`
  > - `markdownlint-cli2 tui-scrollview/README.md`
</blockquote>

## `tui-widgets`

<blockquote>

## [0.7.8] - 2026-06-14

### 🚀 Features

- *(big-text)* Render by reference ([#288](https://github.com/ratatui/tui-widgets/issues/288))
  > ## Summary
  >
  > - add `Widget for &BigText`
  > - keep the owned `Widget for BigText` path as a compatibility shim
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`

- *(equalizer)* Render by reference ([#290](https://github.com/ratatui/tui-widgets/issues/290))
  > ## Summary
  >
  > - add `Widget for &Equalizer`
  > - make band rendering borrow each band instead of consuming it
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`

- *(bar-graph)* Render by reference ([#289](https://github.com/ratatui/tui-widgets/issues/289))
  > ## Summary
  >
  > - add `Widget for &BarGraph`
  > - keep the owned `Widget for BarGraph` path as a compatibility shim
  > - cover borrowed rendering against owned rendering
  >
  > ## Validation
  >
  > - `cargo test -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-big-text -p tui-bar-graph -p tui-equalizer -p
  > tui-prompts -p tui-scrollview --all-targets --all-features -- -D
  > warnings`

- *(prompts)* Render text prompts by reference ([#291](https://github.com/ratatui/tui-widgets/issues/291))
  > ## Summary
  >
  > - add `StatefulWidget for &TextPrompt`
  > - add `Prompt for &TextPrompt` so stored prompt configuration can be
  > drawn by reference
  > - document the stored prompt pattern and regenerate the README
  >
  > ## Validation
  >
  > - `cargo test -p tui-prompts --all-features`
  > - `cargo clippy -p tui-prompts --all-targets --all-features -- -D
  > warnings`
  > - `cargo rdme --check --manifest-path tui-prompts/Cargo.toml`
  > - `markdownlint-cli2 tui-prompts/README.md`

- *(scrollview)* Render by reference ([#292](https://github.com/ratatui/tui-widgets/issues/292))
  > ## Summary
  >
  > - add `StatefulWidget for &ScrollView`
  > - keep the owned `StatefulWidget for ScrollView` path as a compatibility
  > shim
  > - document the stored scroll view pattern and regenerate the README
  >
  > ## Validation
  >
  > - `cargo test -p tui-scrollview --all-features`
  > - `cargo clippy -p tui-scrollview --all-targets --all-features -- -D
  > warnings`
  > - `cargo rdme --check --manifest-path tui-scrollview/Cargo.toml`
  > - `markdownlint-cli2 tui-scrollview/README.md`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).