### PR TITLE
fix(prompts): repair select example CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@
   interactive flows.
 - Before pushing changes that touch crate-level `src/lib.rs` docs or any `README.md`, run
   `just rdme-check` and regenerate stale READMEs with `cargo rdme --manifest-path <crate>/Cargo.toml`.
+- Treat formatter changes to crate-level Rustdoc in `src/lib.rs` as README-affecting docs changes;
+  rustfmt import reordering inside doc examples can make `cargo rdme --check` fail.
 - Document safety/contracts for unsafe or performance-sensitive code; call out terminal assumptions
   (color, size) and error conditions.
 

--- a/tui-prompts/README.md
+++ b/tui-prompts/README.md
@@ -104,8 +104,8 @@ the focused option, Enter completes the prompt, and Escape or Ctrl+C aborts it.
 use std::borrow::Cow;
 
 use crossterm::event::KeyEvent;
-use ratatui::layout::Rect;
 use ratatui::Frame;
+use ratatui::layout::Rect;
 use tui_prompts::{Prompt, SelectPrompt, SelectState};
 
 struct App {

--- a/tui-prompts/examples/select.rs
+++ b/tui-prompts/examples/select.rs
@@ -1,15 +1,13 @@
-mod tui;
-
 use std::borrow::Cow;
 use std::thread::sleep;
 use std::time::Duration;
 
 use clap::Parser;
 use color_eyre::Result;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent};
+use ratatui::DefaultTerminal;
+use ratatui::crossterm::event::{self, KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
-use tui::Tui;
 use tui_prompts::prelude::*;
 
 #[derive(Parser)]
@@ -19,10 +17,10 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
+    color_eyre::install()?;
     let cli = Cli::parse();
     let mut app = App::new(cli);
-    app.run()?;
-    Ok(())
+    ratatui::run(|terminal| app.run(terminal))
 }
 
 const FRUITS: [&str; 4] = ["Apple", "Banana", "Cherry", "Date"];
@@ -44,24 +42,22 @@ impl App {
         }
     }
 
-    pub fn run(&mut self) -> Result<()> {
-        let mut tui = Tui::new()?;
-
+    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> Result<()> {
         while !self.is_finished() {
             self.handle_events()?;
-            tui.draw(|frame| self.draw_ui(frame))?;
+            terminal.draw(|frame| self.draw_ui(frame))?;
         }
-        tui.hide_cursor()?;
+        terminal.hide_cursor()?;
         // wait two seconds before exiting so the user can see the final state of the UI.
         sleep(Duration::from_secs(2));
         Ok(())
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        if event::poll(Duration::from_millis(16))? {
-            if let Event::Key(key_event) = event::read()? {
-                self.handle_key_event(key_event);
-            }
+        if event::poll(Duration::from_millis(16))?
+            && let Some(key_event) = event::read()?.as_key_press_event()
+        {
+            self.handle_key_event(key_event);
         }
         Ok(())
     }

--- a/tui-prompts/src/lib.rs
+++ b/tui-prompts/src/lib.rs
@@ -100,8 +100,8 @@
 //! use std::borrow::Cow;
 //!
 //! use crossterm::event::KeyEvent;
-//! use ratatui::layout::Rect;
 //! use ratatui::Frame;
+//! use ratatui::layout::Rect;
 //! use tui_prompts::{Prompt, SelectPrompt, SelectState};
 //!
 //! struct App {

--- a/tui-prompts/src/select_prompt.rs
+++ b/tui-prompts/src/select_prompt.rs
@@ -254,9 +254,9 @@ const fn visible_window_start(
 
 #[cfg(test)]
 mod tests {
+    use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::widgets::Borders;
-    use ratatui::Terminal;
     use rstest::{fixture, rstest};
 
     use super::*;


### PR DESCRIPTION
## Summary

- repair the `tui-prompts` select example after the local `tui` helper module was removed
- align the example with the other `tui-prompts` examples by using `ratatui::run` / `DefaultTerminal`
- regenerate the `tui-prompts` README after rustfmt import ordering changed crate-level Rustdoc
- clarify AGENTS guidance so formatter-generated crate Rustdoc changes still trigger `just rdme-check`

## Context

The open Dependabot PRs are inheriting a `main` CI failure from commit `2d37086b`: `tui-prompts/examples/select.rs` still declares `mod tui;`, but there is no `tui-prompts/examples/tui.rs`. That breaks Check Targets and Clippy, and rustfmt also reports stale import ordering. The README check also failed because `cargo rdme` mirrors the crate-level Rustdoc import ordering into `tui-prompts/README.md`.

## Verification

- `just fmt-check`
- `cargo check --all-targets --all-features --workspace`
- `just clippy-stable`
- `just clippy-beta`
- `cargo test --all-features --workspace`
- `just rdme-check`
- `markdownlint-cli2 AGENTS.md tui-prompts/README.md`
