### PR TITLE
ci: create one release-plz PR

### DIFF
--- a/.github/release-plz/tui-bar-graph.toml
+++ b/.github/release-plz/tui-bar-graph.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-bar-graph-"

--- a/.github/release-plz/tui-big-text.toml
+++ b/.github/release-plz/tui-big-text.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-big-text-"

--- a/.github/release-plz/tui-box-text.toml
+++ b/.github/release-plz/tui-box-text.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-box-text-"

--- a/.github/release-plz/tui-cards.toml
+++ b/.github/release-plz/tui-cards.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-cards-"

--- a/.github/release-plz/tui-equalizer.toml
+++ b/.github/release-plz/tui-equalizer.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-equalizer-"

--- a/.github/release-plz/tui-popup.toml
+++ b/.github/release-plz/tui-popup.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-popup-"

--- a/.github/release-plz/tui-prompts.toml
+++ b/.github/release-plz/tui-prompts.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-prompts-"

--- a/.github/release-plz/tui-qrcode.toml
+++ b/.github/release-plz/tui-qrcode.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-qrcode-"

--- a/.github/release-plz/tui-scrollbar.toml
+++ b/.github/release-plz/tui-scrollbar.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-scrollbar-"

--- a/.github/release-plz/tui-scrollview.toml
+++ b/.github/release-plz/tui-scrollview.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-scrollview-"

--- a/.github/release-plz/tui-widgets.toml
+++ b/.github/release-plz/tui-widgets.toml
@@ -1,3 +1,0 @@
-[workspace]
-changelog_config = "cliff.toml"
-pr_branch_prefix = "release-plz-tui-widgets-"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,26 +36,11 @@ jobs:
     name: Release-plz PR
     if: ${{ github.repository_owner == 'ratatui' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - tui-widgets
-          - tui-bar-graph
-          - tui-big-text
-          - tui-box-text
-          - tui-cards
-          - tui-equalizer
-          - tui-popup
-          - tui-prompts
-          - tui-qrcode
-          - tui-scrollbar
-          - tui-scrollview
     permissions:
       contents: write
       pull-requests: write
     concurrency:
-      group: release-plz-${{ github.ref }}-${{ matrix.package }}
+      group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - name: Checkout repository
@@ -73,9 +59,7 @@ jobs:
       - name: Run release-plz (release-pr)
         run: >
           release-plz release-pr
-          --git-token "${{ secrets.GITHUB_TOKEN }}"
           --repo-url "https://github.com/${{ github.repository }}"
-          --package "${{ matrix.package }}"
-          --config ".github/release-plz/${{ matrix.package }}.toml"
         env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,3 @@
 [workspace]
 changelog_config = "cliff.toml"
+pr_branch_prefix = "release-plz-"


### PR DESCRIPTION
## Summary

- replace the package matrix in the release-plz PR job with one workspace-level invocation
- use the root `release-plz.toml` for the shared changelog config and release PR branch prefix
- remove the per-package release-plz config files that only existed to vary branch prefixes
- grant the release job `pull-requests: read`, matching release-plz's documented permission for detecting the release PR and its commits
- pass the CLI Git token through `GIT_TOKEN` instead of interpolating it into the shell command line

## Why

`release-plz release-pr --package <name>` narrows the update to a single package. Running that in a matrix creates separate package-scoped release PRs, which can cascade as each package release changes `main` and refreshes the remaining package PRs. Running `release-plz release-pr` once from the workspace root lets release-plz prepare one combined release PR for all ready workspace package updates.

The release publishing job still runs `release-plz release` on pushes to `main`; this only adds the documented read permission it needs for release-PR detection.

This does not switch away from `GITHUB_TOKEN`. Release-plz's docs note that default-token-created release PRs and tags do not trigger follow-on workflows. Fixing that would require a configured PAT or GitHub App secret, which should be a separate repo policy change.

## Validation

- `actionlint .github/workflows/release-plz.yml`
- temp clone with this patch applied: `release-plz update --allow-dirty --repo-url https://github.com/ratatui/tui-widgets`
